### PR TITLE
UIP-2429: Get tests passing with the DDC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - "1.22.0"
+  - "1.23.0"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: ">=1.22.0"
 dependencies:
   matcher: ">=0.11.0 <0.13.0"
-  over_react: "^1.8.0"
-  react: "^3.1.0"
-  test: "^0.12.6+2"
+  over_react: "^1.12.1"
+  react: "^3.4.0"
+  test: "^0.12.20+1"
 dev_dependencies:
   coverage: "^0.7.2"
-  dart_dev: "^1.0.5"
+  dart_dev: "^1.7.7"
 transformers:
   - over_react
   - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Workiva/over_react_test/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.22.0"
+  sdk: ">=1.23.0"
 dependencies:
   matcher: ">=0.11.0 <0.13.0"
   over_react: "^1.12.1"

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,10 +1,11 @@
 project: dart
 language: dart
 
-# dart 1.22.0, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-dart:124921
+# Dart 1.23.0 image from https://github.com/Workiva/smithy-runner-generator
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818
 
 script:
+  - dart --version
   - pub get
   # Do not run tests on smithy, because they keep timing out.
   # - ./tool/smithy_dart2js_tests.sh


### PR DESCRIPTION
## Ultimate problem:
We want to make sure the tests can be run with the DDC

## How it was fixed:
- Bump dep version constraints

## Testing suggestions:
- Verify tests pass by:
  - Run `pub serve test --web-compiler=dartdevc` in one terminal
  - And `pub run test -p chrome --pub-serve=8080 test/over_react_test.dart` in another terminal

## Potential areas of regression:
N/A

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
