### PR TITLE
UIP-2464 Update prop error matcher

### DIFF
--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -306,7 +306,7 @@ Matcher throwsPropError_Required(String propName, [String message = '']) {
 Matcher throwsPropError_Value(dynamic invalidValue, String propName, [String message = '']) {
   return throwsA(anyOf(
       hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
-      hasToStringValue(contains('InvalidPropValueError: Prop $propName set to ${Error.safeToString(invalidValue)}. '
+      hasToStringValue(contains('InvalidPropValueError: Prop $propName set to $invalidValue. '
           '$message'.trim()
       ))
   ));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,11 @@ dependencies:
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.7"
+depedency_overrides:
+  over_react:
+    git:
+      url: https://github.com/jacehensley-wf/over_react.git
+      ref: af848e7fd18f3c7be80affc2c716a99748dbe9d2
 transformers:
   - over_react
   - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,17 +8,12 @@ environment:
   sdk: ">=1.23.0"
 dependencies:
   matcher: ">=0.11.0 <0.13.0"
-  over_react: "^1.12.1"
+  over_react: "^1.14.0"
   react: "^3.4.0"
   test: "^0.12.20+1"
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.7"
-depedency_overrides:
-  over_react:
-    git:
-      url: https://github.com/jacehensley-wf/over_react.git
-      ref: af848e7fd18f3c7be80affc2c716a99748dbe9d2
 transformers:
   - over_react
   - test/pub_serve:


### PR DESCRIPTION
> Related to: https://github.com/Workiva/over_react/pull/92

## Ultimate problem:
When running tests in the DDC the `Error.safeToString` was kinda a PITA

## How it was fixed:
- Do not use `Error.safeToString`

## Testing suggestions:
Verify tests still pass

## Potential areas of regression:
N/A

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
