### PR TITLE
Add custom matcher for AssertionError

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,7 +34,7 @@ linter:
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     # - non_constant_identifier_names
-    - omit_local_variable_types
+    # - omit_local_variable_types
     # - one_member_abstracts
     - only_throw_errors
     # - overridden_fields
@@ -46,10 +46,10 @@ linter:
     - prefer_collection_literals
     - prefer_const_constructors
     - prefer_contains
-    - prefer_expression_function_bodies
+    # - prefer_expression_function_bodies
     # - prefer_final_fields
     # - prefer_final_locals
-    - prefer_function_declarations_over_variables
+    # - prefer_function_declarations_over_variables
     - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty

--- a/lib/over_react_test.dart
+++ b/lib/over_react_test.dart
@@ -14,6 +14,6 @@
 
 export 'src/over_react_test/custom_matchers.dart';
 export 'src/over_react_test/dom_util.dart';
+export 'src/over_react_test/jacket.dart';
 export 'src/over_react_test/react_util.dart';
 export 'src/over_react_test/wrapper_component.dart';
-export 'src/over_react_test/jacket.dart';

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -277,6 +277,16 @@ class _IsFocused extends Matcher {
 /// A matcher that matches the currently focused element (`document.activeElement`).
 const Matcher isFocused = const _IsFocused();
 
+/// A matcher to verify that an [AssertionError] is thrown.
+///
+/// Necessary since the following does not work consistently on all platforms:
+///
+///     throwsA(const isInstanceOf<AssertionError>());
+final Matcher throwsAssertionError = throwsA(anyOf(
+  hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
+  hasToStringValue(contains('AssertionError')),
+));
+
 /// A matcher to verify that a [PropError] is thrown with a provided `propName` and `message`.
 ///
 /// __Note__: The message is matched rather than the [Error] instance due to Dart's wrapping of all `throw`

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -285,6 +285,7 @@ const Matcher isFocused = const _IsFocused();
 final Matcher throwsAssertionError = throwsA(anyOf(
   hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
   hasToStringValue(contains('AssertionError')),
+  hasToStringValue(contains('Failed assertion')),
 ));
 
 /// A matcher to verify that a [PropError] is thrown with a provided `propName` and `message`.

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -433,6 +433,10 @@ main() {
       });
     });
 
+    test('throwsAssertionError', () {
+      expect(() {assert(true == false);}, throwsAssertionError);
+    });
+
     test('throwsPropError', () {
       expect(() => throw new PropError('propName', 'message'), throwsPropError('propName', 'message'));
     });

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -387,7 +387,9 @@ main() {
         });
 
         tearDown(() {
-          allAttachedNodes.forEach((node) => node.remove());
+          for (var node in allAttachedNodes) {
+            node.remove();
+          }
           allAttachedNodes.clear();
         });
 

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -21,8 +21,8 @@ import 'package:react/react_client.dart';
 import 'package:test/test.dart';
 import 'package:over_react_test/over_react_test.dart';
 
-import './utils/test_js_component.dart';
 import './utils/nested_component.dart';
+import './utils/test_js_component.dart';
 
 /// Main entry point for ReactUtil testing
 main() {

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -29,8 +29,6 @@ main(List<String> args) async {
     ..platforms = [
       'content-shell',
     ]
-    // Prevent test load timeouts.
-    ..concurrency = 1
     ..unitTests = [
       'test/over_react_test.dart',
     ];


### PR DESCRIPTION
## Ultimate problem:
Consumers attempting to address the deprecation of the `throws` matcher within the `dart-lang/test` package are blocked by the fact that the following matcher does not work consistently on all platforms:

```dart
throwsA(const isInstanceOf<AssertionError>())
```

## How it was fixed:
Add a custom matcher, complete with a workaround for https://github.com/dart-lang/sdk/issues/26093

> I also relaxed a few lints that were quite noisy, and addressed some low-hanging-fruit lints.

## Testing suggestions:
Passing CI

## Areas of regression
None expected, new functionality only.

---

__FYA:__ @jacehensley-wf @greglittlefield-wf @clairesarsam-wf 

