### PR TITLE
UIP-2465 Release over_react_test 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: dart
+dist: precise
 dart:
   - "1.23.0"
 with_content_shell: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 1.0.1
+version: 1.1.0
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2512 Add more utils from over_react](https://github.com/Workiva/over_react_test/pull/11)


Requested by: @jacehensley-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/1.0.1...version-bump-over_react_test-1-1-0_4
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/1.0.1...1.1.0