### PR TITLE
Declare direct dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,10 @@ authors:
 environment:
   sdk: ">=1.23.0"
 dependencies:
+  js: "^0.6.1"
   matcher: ">=0.11.0 <0.13.0"
   over_react: "^1.14.0"
+  platform_detect: "^1.3.2"
   react: "^3.4.0"
   test: "^0.12.24"
 dev_dependencies:


### PR DESCRIPTION
## Ultimate problem:
In the most recent run of `pub publish`, 2 packages were pointed out as being used within `lib/src`, but not declared as dependencies.

## How it was fixed:
Added `js` and `platform_detect` as dependencies.

## Testing suggestions:
1. Pull this branch locally / run `pub get`
2. Run `pub publish --dry-run`
3. Verify that there are no warnings

## Areas of regression
None expected

---

__FYA:__ @jacehensley-wf @greglittlefield-wf @clairesarsam-wf 
