### PR TITLE
UIP-2681 Widen react-dart range to pull in memory leak fixes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   matcher: ">=0.11.0 <0.13.0"
   over_react: "^1.14.0"
   platform_detect: "^1.3.2"
-  react: "^3.4.0"
+  react: ">=3.4.0 <5.0.0"
   test: "^0.12.24"
 dev_dependencies:
   coverage: "^0.7.2"


### PR DESCRIPTION
## Dependency, config, and/or RM change callouts
Widen react-dart dependency to include 4.0.0.

## Problem
react-dart 4.0.0 includes improvements to Dart component instance management that help avoid certain memory leaks. See more info here: https://github.com/cleandart/react-dart/pull/127.

While this release contains breaking changes, those breakages are limited to internals that should be smoothed over by over_react, and should not affect the majority of consumers.

## Solution
Widen react-dart version range to include 4.0.0.

Once this range has been widened throughout the Workiva's dependency tree, everyone should get 4.0.0 for free.

## Test Overview (+10 Instructions)
- [ ] Verify that `pub get` still resolves properly in the build, and tests still pass
     - (This PR will likely not result in any changes to resolved dependencies)
- [ ] Verify that unit tests still pass when react-dart 4.0.0 is actually pulled in
    1. Add the following to your pubspec.yaml:
       ```yaml
       dependency_overrides:
         react: ^4.0.0
         over_react:
           git:
             url: git@github.com:Workiva/over_react.git
             ref: 54857531bce7e821bc0c02cb09d6bd40a65170c5 # from react-dart-4.0.0 - Mon Aug 28 15:51:00 2017 -0700
        ```
    2. Run `pub get --packages-dir`
    3. Run unit tests

## Semantic Versioning
**Patch**
- [x] This change does not affect the public API

## Areas of Regression
React component rendering/testing

---

@Workiva/ui-platform-pp 