### PR TITLE
UIP-2638 Release over_react_test 1.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 1.2.1
+version: 1.2.2
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2674 add docs.yaml](https://github.com/Workiva/over_react_test/pull/20)
* [UIP-2681 Widen react-dart range to pull in memory leak fixes](https://github.com/Workiva/over_react_test/pull/21)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/1.2.1...Workiva:release_over_react_test_1_2_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/1.2.1...1.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)