### PR TITLE
UIP-2718 Make triggerTransitionEnd work for Chrome 61

### DIFF
--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -40,8 +40,14 @@ Future triggerTransitionEnd(Element element) {
     jsEvent = new JsObject.fromBrowserObject(jsDocument.callMethod('createEvent', ['Event']));
   }
 
-  // Need to use webkitTransitionEnd in Edge. See https://github.com/dart-lang/sdk/issues/26972
-  var eventName = (browser.isInternetExplorer && browser.version.major > 11) ? 'webkitTransitionEnd' : 'transitionend';
+  var eventName;
+  if ((browser.isChrome && browser.version.major >= 61) ||
+      (browser.isInternetExplorer && browser.version.major > 11)) {
+    // Need to use webkitTransitionEnd in Edge and Chrome>=61. See https://github.com/dart-lang/sdk/issues/26972
+    eventName  = 'webkitTransitionEnd';
+  } else {
+    eventName = 'transitionend';
+  }
 
   jsEvent.callMethod('initEvent', [eventName, true, true]);
 

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -269,7 +269,7 @@ main() {
       });
 
       group('fails when the props are different in a', () {
-        final failMessagePattern = new RegExp(r"Which: has props/attributes map with value .* which is different. Expected: test +Actual: different");
+        final failMessagePattern = new RegExp(r"Which: has props/attributes map with value .* is different. Expected: test +Actual: different");
 
         group('ReactElement', () {
           test('(DOM)', () {


### PR DESCRIPTION
## Ultimate problem:
- `triggerTransitionEnd` no longer works as expected in Chrome 61 due to https://github.com/dart-lang/sdk/issues/26972.
- When `triggerFocus` and `triggerTransitionEnd` fail, they cause tests to hang until they time out

## How it was fixed:
- Fix `triggerTransitionEnd` in Chrome 61
- Add reasonable timeouts to `triggerFocus` and `triggerTransitionEnd` so that they don't cause tests to hang for as long

## Testing suggestions:
- Verify CI passes
- Verify all unit tests pass in Chrome 61 (you may need to keep the browser window focused)

## Potential areas of regression:
`triggerFocus` and `triggerTransitionEnd` 

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
