### PR TITLE
UIP-2686 Release over_react_test 1.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 1.2.2
+version: 1.3.0
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2718 Make triggerTransitionEnd work for Chrome 61](https://github.com/Workiva/over_react_test/pull/23)


Requested by: @clairesarsam-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/1.2.2...Workiva:release_over_react_test_1_3_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/1.2.2...1.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)