### PR TITLE
UIP-2727 Release over_react_test 1.3.1

### DIFF
--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -16,8 +16,6 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:js';
 
-import 'package:platform_detect/platform_detect.dart';
-
 const Duration _defaultTriggerTimeout = const Duration(seconds: 3);
 
 /// Dispatches a `transitionend` event when the CSS transition of the [element]
@@ -42,14 +40,7 @@ Future triggerTransitionEnd(Element element, {Duration timeout: _defaultTriggerT
     jsEvent = new JsObject.fromBrowserObject(jsDocument.callMethod('createEvent', ['Event']));
   }
 
-  var eventName;
-  if ((browser.isChrome && browser.version.major >= 61) ||
-      (browser.isInternetExplorer && browser.version.major > 11)) {
-    // Need to use webkitTransitionEnd in Edge and Chrome>=61. See https://github.com/dart-lang/sdk/issues/26972
-    eventName  = 'webkitTransitionEnd';
-  } else {
-    eventName = 'transitionend';
-  }
+  var eventName = Element.transitionEndEvent.getEventType(element);
 
   jsEvent.callMethod('initEvent', [eventName, true, true]);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 1.3.0
+version: 1.3.1
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:


### PR DESCRIPTION
## Ultimate problem:
`triggerTransitionEnd` was timing out in content-shell.

## How it was fixed:
Use the `Element.transitionEndEvent.getEventType(...)` API to ensure the name of event we're dispatching is the same name used by the `onTransitionEnd` stream. 

Lucky this API exists; now we don't have to guess!

## Testing suggestions:
* Verify all tests pass locally in content-shell.
* Verify that all parts of WSD build (Smithy, coverage, JS unit tests pass)
    * Test branch: https://github.com/greglittlefield-wf/web_skin_dart/branches/all?utf8=%E2%9C%93&query=transitionend_fix_test

## Potential areas of regression:
`triggerTransitionEnd`


---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
