### PR TITLE
UIP-2888 Use dependency_validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 dist: precise
 dart:
-  - "1.23.0"
+  - "1.24.2"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev analyze
+  - pub run dependency_validator -i coverage
   - pub run dart_dev test
   - ./tool/generate_coverage.sh
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,18 +7,17 @@ authors:
 environment:
   sdk: ">=1.23.0"
 dependencies:
-  js: "^0.6.1"
+  js: ^0.6.1
   matcher: ">=0.11.0 <0.13.0"
-  over_react: "^1.14.0"
-  platform_detect: "^1.3.2"
+  over_react: ^1.14.0
+  platform_detect: ^1.3.2
   react: ">=3.4.0 <5.0.0"
-  test: "^0.12.24"
+  test: ^0.12.24
 dev_dependencies:
-  coverage: "^0.7.2"
-  dart_dev: "^1.7.7"
+  coverage: ^0.7.2
+  dart_dev: ^1.7.7
+  dependency_validator: ^1.0.0
 transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
-  # Reminder: dart2js should come after any other transformers that touch Dart code
-  - $dart2js

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Workiva/over_react_test/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.23.0"
+  sdk: ">=1.24.2"
 dependencies:
   js: ^0.6.1
   matcher: ">=0.11.0 <0.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   js: ^0.6.1
   matcher: ">=0.11.0 <0.13.0"
   over_react: ^1.14.0
-  platform_detect: ^1.3.2
   react: ">=3.4.0 <5.0.0"
   test: ^0.12.24
 dev_dependencies:

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# Dart 1.23.0 image from https://github.com/Workiva/smithy-runner-generator
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818
+# Dart 1.24.2 image from https://github.com/Workiva/smithy-runner-generator
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735
 
 script:
   - dart --version


### PR DESCRIPTION
## Ultimate problem:
Now that `dependency_validator` is published we should use it.

## How it was fixed:
- Add `dependency_validator` as a dev dep and runs its check during CI.

## Testing suggestions:
- Verify CI still passes

## Potential areas of regression:
N/A

---
FYA: @Workiva/ui-platform-pp @Workiva/web-platform-pp 