### PR TITLE
UIP-3073 Do not run @requiredProp commonComponentTests in dart2js runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,45 @@
 # OverReact Test Changelog
 
+## 1.3.1
+
+__Bugs Fixed__
+
+* [#25]: Make `triggerTransitionEnd` work in content-shell _(regression introduced via [#23])_.
+
+## 1.3.0
+
+__Misc__
+
+* [#23]: Make `triggerTransitionEnd` work in Chrome 61.
+
+## 1.2.2
+
+__Misc__
+
+* [#20]: Add docs.yaml.
+* [#21]: Widen `react` dependency range to pull in memory leak fixes.
+
+## 1.2.1
+
+__Bugs Fixed__
+
+* [#18]: Do not do anything outside of test blocks in `commonComponentTests`.
+
+## 1.2.0
+
+__New Features__
+
+* [#16]: Support passing in components in `getByTestId`.
+
+__Misc__
+
+* [#15]: Test that `testId` is forwarded in `commonComponentTests`.
+
 ## 1.1.1
 
 __Bugs Fixed__
 
-* Sync common component test src with the lib it originated from.
+* [#14]: Sync common component test src with the lib it originated from.
 
 ## 1.1.0
 
@@ -16,11 +51,17 @@ __New Features__
 
 __Misc__
 
-* [#8]: Update prop error message to make it more DDC friendly
+* [#8]: Update prop error message to make it more DDC friendly.
 
 ## 1.0.0
 
-Initial public release of library.
+Initial public release of the library.
+
+* [#1]: Split out test_utils into its own package.
+* [#2]: Set up travis and codecov for OSS.
+* [#3]: Add test ID naming conventions.
+* [#4]: Add initial aviary.yaml file.
+* [#5]: Update dart doc badge.
 
 
 

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -35,6 +35,6 @@ main() {
           shouldTestClassNameMerging: false,
           shouldTestClassNameOverrides: false,
           shouldTestPropForwarding: false);
-    });
+    }, testOn: '!js');
   });
 }


### PR DESCRIPTION
## Ultimate problem:
https://github.com/Workiva/over_react/pull/142 will make it so that `@requiredProp`-annotated props are not validated in dart2js output.  The `commonComponentTests` function runs some required props validation tests for consumers - no matter if the test is being run in the JS runtime or not.


## How it was fixed:
1. Only run the `@requiredProp` annotation tests when the runtime is not `dart2js`.


## Testing suggestions:
1. Pull this branch locally
2. Add this to your `pubspec.yaml` file:
    ```yaml
    dependency_overrides:
      over_react:
        git:
          url: git@github.com:Workiva/over_react.git
          ref: no-prop-validation-in-dart2js-builds
    ```
3. Run `pub get` and `ddev test -p chrome`
4. Verify that all tests pass in chrome. 
    * _(NOTE: focusing the chrome window running the tests greatly speeds up test execution)_.


## Potential areas of regression:
Tests

---

> __FYA:__ @Workiva/ui-platform-pp @sebastianmalysa-wf @evanweible-wf @corwinsheahan-wf 
