### PR TITLE
Include ssh access in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,18 @@ ARG GIT_COMMIT_RANGE
 ARG GIT_HEAD_URL
 ARG GIT_MERGE_HEAD
 ARG GIT_MERGE_BRANCH
+# Expose env vars for git ssh access
+ARG GIT_SSH_KEY
+ARG KNOWN_HOSTS_CONTENT
+# Install SSH keys for git ssh access
+RUN mkdir /root/.ssh
+RUN echo "$KNOWN_HOSTS_CONTENT" > "/root/.ssh/known_hosts"
+RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
+RUN chmod 700 /root/.ssh/
+RUN chmod 600 /root/.ssh/id_rsa
+RUN echo "Setting up ssh-agent for git-based dependencies"
+RUN eval "$(ssh-agent -s)" && \
+	ssh-add /root/.ssh/id_rsa
 WORKDIR /build/
 ADD . /build/
 RUN echo "Starting the script sections" && \


### PR DESCRIPTION
## Ultimate problem:
During consumer testing it was noticed that the Dockerfile didn't have the necessary credentials to pull from a non-pub location (i.e. git).

## How it was fixed:
Include ssh-agent in `Dockerfile`

## Testing suggestions:
Verify build passes. (view the last commit found here, https://github.com/Workiva/over_react_test/pull/33 and ensure that the `pub get` resolves

## Potential areas of regression:
n/a

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
