### PR TITLE
Fix Dart SDK 2 typing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _site
 .pub
 packages
 .packages
+.dart_tool
 build/
 
 

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -387,8 +387,8 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
 /// __Note__: All required props must be provided by [factory].
 void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) {
   var keyToErrorMessage = {};
-  var nullableProps = [];
-  var requiredProps = [];
+  var nullableProps = <String>[];
+  var requiredProps = <String>[];
 
   setUp(() {
     var jacket = mount(factory()(childrenFactory()), autoTearDown: false);

--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -23,7 +23,7 @@ const Duration _defaultTriggerTimeout = const Duration(seconds: 3);
 ///
 /// Used for testing components that rely on a `transitionend` event.
 Future triggerTransitionEnd(Element element, {Duration timeout: _defaultTriggerTimeout}) {
-  Future eventFiredFuture = element.onTransitionEnd.first;
+  var eventFiredFuture = element.onTransitionEnd.first;
 
   // Use JS interop to construct a native TransitionEvent since Dart doesn't allow instantiating them directly.
   // TODO: move this to JS so we can use TransitionEvent constructor
@@ -31,7 +31,7 @@ Future triggerTransitionEnd(Element element, {Duration timeout: _defaultTriggerT
   var jsElement = new JsObject.fromBrowserObject(element);
   var jsDocument = new JsObject.fromBrowserObject(document);
 
-  var jsEvent;
+  JsObject jsEvent;
   try {
     // Dartium requires it actually to be a `TransitionEvent`, not `Event`.
     jsEvent = new JsObject.fromBrowserObject(jsDocument.callMethod('createEvent', ['TransitionEvent']));


### PR DESCRIPTION
## Ultimate problem:
https://github.com/Workiva/over_react/pull/155 uncovered some runtime type errors in this library.

## How it was fixed:
Fixed the type errors.

## Testing suggestions:
Run the tests on the https://github.com/Workiva/over_react/pull/155 branch using the `2.0.0-dev.49.0` release of the Dart SDK.

## Potential areas of regression:
None expected

---
> __FYA:__ @greglittlefield-wf @clairesarsam-wf
