### PR TITLE
AF-321: Add generic triggerDocumentMouseEvent util for non click events

### DIFF
--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -54,11 +54,18 @@ Future triggerTransitionEnd(Element element, {Duration timeout: _defaultTriggerT
 ///
 /// Verifies that the [target] element is not a detached node.
 void triggerDocumentClick(Element target) {
+  triggerDocumentMouseEvent(target, 'click');
+}
+
+/// Dispatches a [MouseEvent] of type [event] to the specified [target].
+///
+/// Verifies that the [target] element is not a detached node.
+void triggerDocumentMouseEvent(Element target, String event) {
   if (!document.documentElement.contains(target)) {
     throw new ArgumentError.value(target, 'target', 'Target should be attached to the document.');
   }
 
-  target.dispatchEvent(new MouseEvent('click'));
+  target.dispatchEvent(new MouseEvent(event));
 }
 
 /// Focuses the [target] and returns a [Future] when that `focus` event is fired.

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -55,6 +55,29 @@ main() {
     });
   });
 
+  group('triggerDocumentMouseEvent correctly dispatches an event', () {
+    var flag;
+
+    setUp((){
+      flag = false;
+    });
+
+    test('when the target is attached to the document', () {
+      var renderedInstance = renderAttachedToDocument((Dom.div()..onMouseDown = ((_) => flag = true))());
+
+      triggerDocumentMouseEvent(findDomNode(renderedInstance), 'mousedown');
+
+      expect(flag, isTrue);
+    });
+
+    test('and throws when the target is not attached to the document', () {
+      var renderedInstance = render((Dom.div()..onMouseDown = ((_) => flag = true))());
+
+      expect(() => triggerDocumentMouseEvent(findDomNode(renderedInstance), 'mousedown'), throwsArgumentError);
+      expect(flag, isFalse);
+    });
+  });
+
   group('triggerFocus correctly dispatches a focus event', () {
     var flag;
 


### PR DESCRIPTION
## Ultimate problem:

The logic previously contained in `triggerDocumentClick` is actually useful for all kinds of different mouse events.

## How it was fixed:

Move logic to a new method, `triggerDocumentMouseEvent`, which can be used to trigger any type of mouseevent.

## Testing suggestions:

Tests should pass.

## Potential areas of regression:

None.

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
