### PR TITLE
af_new_drydock_image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: dart
 dist: precise
 dart:
   - "1.24.2"
+env:
+  - DARTIUM_EXPIRATION_TIME="1577836800"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -27,7 +27,7 @@ main(List<String> args) async {
   config.test
     ..pubServe = true
     ..platforms = [
-      'content-shell',
+      'dartium',
     ]
     ..unitTests = [
       'test/over_react_test.dart',


### PR DESCRIPTION
## Purpose

The following pull request has been created by App Frameworks to help move consumers to the latest Smithy image. This was done because of an issue with Dartium and Content-Shell that would fail your CIs. Please seethis [Wiki Question](https://wiki.atl.workiva.net/cq/viewquestion.action?id=96308901&answerId=96308907)for additional context.

## Changes

The following changes have been made:
* All instances of the production Smithy image have been updated to `drydock-prod.workiva.net/workiva/smithy-runner-generator:355624`.

## Questions

If you have any questions, please reach out to us in the Support:H5 / Dart Hipchat room