### PR TITLE
AF-1950 Fix typo in jacket.dart

### DIFF
--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -100,7 +100,7 @@ class TestJacket<T extends react.Component> {
     return over_react.findDomNode(_renderedInstance);
   }
 
-  /// Returns the native Dart compoentn associated with the mounted React component instance, or null if the component
+  /// Returns the native Dart component associated with the mounted React component instance, or null if the component
   /// is not Dart based.
   T getDartInstance() {
     return over_react.getDartComponent(_renderedInstance) as T;


### PR DESCRIPTION
## Ultimate problem:
- There was a typo in jacket.dart

## How it was fixed:
- Fixed the typo

## Testing suggestions:
- CI should still be happy

## Potential areas of regression:
- None

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
