### PR TITLE
AF-2001 Add a TestJacket-only library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN chmod 600 /root/.ssh/id_rsa
 RUN echo "Setting up ssh-agent for git-based dependencies"
 RUN eval "$(ssh-agent -s)" && \
 	ssh-add /root/.ssh/id_rsa
+ENV DARTIUM_EXPIRATION_TIME=1577836800
 WORKDIR /build/
 ADD . /build/
 RUN echo "Starting the script sections" && \
@@ -30,5 +31,7 @@ RUN echo "Starting the script sections" && \
 		pub get && \
         pub run dependency_validator -i coverage && \
 		echo "Script sections completed"
+ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
+ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock
 FROM scratch

--- a/lib/jacket.dart
+++ b/lib/jacket.dart
@@ -1,0 +1,15 @@
+// Copyright 2018 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'src/over_react_test/jacket.dart';

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -16,7 +16,6 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart' as over_react;
 import 'package:react/react.dart' as react;
-import 'package:react/react_client.dart' show ReactElement;
 import 'package:react/react_client/react_interop.dart' show ReactComponent;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 
@@ -44,7 +43,7 @@ import 'package:over_react_test/src/over_react_test/react_util.dart' as react_ut
 /// To render into a node attached to document.body, as opposed to a detached node, set [attachedToDocument] to true.
 ///
 /// To have the instance not automatically unmounted when the test if over set [autoTearDown] to `false`.
-TestJacket<T> mount<T extends react.Component>(ReactElement reactElement, {
+TestJacket<T> mount<T extends react.Component>(over_react.ReactElement reactElement, {
     Element mountNode,
     bool attachedToDocument: false,
     bool autoTearDown: true
@@ -63,21 +62,21 @@ class TestJacket<T extends react.Component> {
   final bool attachedToDocument;
   final bool autoTearDown;
 
-  TestJacket._(ReactElement reactElement, {Element mountNode, this.attachedToDocument: false, this.autoTearDown: true})
+  TestJacket._(over_react.ReactElement reactElement, {Element mountNode, this.attachedToDocument: false, this.autoTearDown: true})
       : this.mountNode = mountNode ?? (new DivElement()
           ..style.height = '800px'
           ..style.width= '800px') {
     _render(reactElement);
   }
 
-  void _render(ReactElement reactElement) {
+  void _render(over_react.ReactElement reactElement) {
     _renderedInstance = attachedToDocument
         ? react_util.renderAttachedToDocument(reactElement, container: mountNode, autoTearDown: autoTearDown)
         : react_util.render(reactElement, container: mountNode, autoTearDown: autoTearDown);
   }
 
   /// Rerenders the [reactElement] into the same [mountNode].
-  void rerender(ReactElement reactElement) {
+  void rerender(over_react.ReactElement reactElement) {
     _render(reactElement);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,14 +8,14 @@ environment:
   sdk: ">=1.24.2 <2.0.0"
 dependencies:
   js: ^0.6.1
-  matcher: ">=0.11.0 <0.13.0"
-  over_react: ^1.23.0
+  matcher: ^0.12.1+4
+  over_react: ^1.25.0
   react: ">=3.7.0 <5.0.0"
   test: ^0.12.32+1
 dev_dependencies:
   coverage: ">=0.7.2 <0.11.0"
-  dart_dev: ^1.7.7
-  dependency_validator: ^1.1.0
+  dart_dev: ^1.9.6
+  dependency_validator: ^1.2.2
 transformers:
   - over_react
   - test/pub_serve:


### PR DESCRIPTION
## Ultimate problem:
The only library currently exposed by `over_react_test` includes the `TestJacket`, but also all of the react test utilities.  Some of the test utilities utilize `mirrors` - which are known to bloat the size of dart2js compiled output.  This is less than ideal for consumers who do not need to make use of any test utilities.

## How it was fixed:
Add a `lib/jacket.dart` entrypoint that only exposes the `TestJacket`.

## Boy Scoutin'
Updated some stale dependency lower bounds.

## Testing suggestions:
CI passes

## Potential areas of regression:
None expected - new entrypoint only.

---
> __FYA:__ @kealjones-wk @clairesarsam-wf @greglittlefield-wf 
