### PR TITLE
AF-3425 Add getAllByTestId

### DIFF
--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -220,12 +220,12 @@ bool _hasTestId(Map props, String key, String value) {
 /// __Example:__
 ///
 ///     var renderedInstance = render(Dom.div()(
-///         // Div1
+///       // Div1
 ///       (Dom.div()..addTestId('first'))(),
 ///
-///         Dom.div()(
-///           // Div2
-///           (Dom.div()
+///       Dom.div()(
+///         // Div2
+///         (Dom.div()
 ///           ..addTestId('second')
 ///           ..addTestId('other-id')
 ///         )(),
@@ -240,37 +240,61 @@ bool _hasTestId(Map props, String key, String value) {
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
 /* [1] */ getByTestId(dynamic root, String value, {String key: defaultTestIdKey}) {
+  final results = getAllByTestId(root, value, key: key);
+  return results.isEmpty ? null : results.first;
+}
+
+/// Returns all descendants of [root] with a [key] test ID prop value set to a
+/// space-delimited string containing [value].
+///
+/// This is similar to [getByTestId], which returns only the first matching descendant.
+///
+/// This method works for:
+///
+/// * `ReactComponent` render trees (output of [render])
+/// * [ReactElement] trees (output of [renderShallow]/`Component.render`)
+///
+/// __Example:__
+///
+///     var renderedInstance = render(Dom.div()(
+///       // Div1
+///       (Dom.div()
+///         ..addTestId('first')
+///         ..addTestId('shared-id')
+///       )(),
+///
+///       Dom.div()(
+///         // Div2
+///         (Dom.div()
+///           ..addTestId('second')
+///           ..addTestId('other-id')
+///           ..addTestId('shared-id')
+///         )(),
+///       ),
+///     ));
+///
+///     var allFirsts  = getAllByTestId(renderedInstance, 'first');    // Returns `[Div1]`
+///     var allSeconds = getAllByTestId(renderedInstance, 'second');   // Returns `[Div2]`
+///     var allOthers  = getAllByTestId(renderedInstance, 'other-id'); // Returns `[Div2]`
+///     var allShared  = getAllByTestId(renderedInstance, 'other-id'); // Returns `[Div1, Div2]`
+///     var allNonexistents = getAllByTestId(renderedInstance, 'nonexistent'); // Returns `null`
+///
+/// It is recommended that, instead of setting this [key] prop manually, you should use the
+/// [UiProps.addTestId] method so the prop is only set in a test environment.
+List/* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defaultTestIdKey}) {
   if (root is react.Component) root = root.jsThis;
 
   if (isValidElement(root)) {
-    return _getByTestIdShallow(root, value, key: key);
+    return _getAllByTestIdShallow(root, value, key: key);
   }
 
-  bool first = false;
-
-  var results = react_test_utils.findAllInRenderedTree(root, allowInterop((descendant) {
-    if (first) {
-      return false;
-    }
-
+  return react_test_utils.findAllInRenderedTree(root, allowInterop((descendant) {
     var props = react_test_utils.isDOMComponent(descendant)
-      ? findDomNode(descendant).attributes
-      : getProps(descendant);
+        ? findDomNode(descendant).attributes
+        : getProps(descendant);
 
-    bool hasValue = _hasTestId(props, key, value);
-
-    if (hasValue) {
-      first = true;
-    }
-
-    return hasValue;
+    return _hasTestId(props, key, value);
   }));
-
-  if (results.isEmpty) {
-    return null;
-  } else {
-    return results.single;
-  }
 }
 
 /// Returns the [Element] of the first descendant of [root] that has its [key] prop value set to [value].
@@ -395,7 +419,7 @@ Map getPropsByTestId(dynamic root, String value, {String key: defaultTestIdKey})
   return null;
 }
 
-ReactElement _getByTestIdShallow(ReactElement root, String value, {String key: defaultTestIdKey}) {
+List<ReactElement> _getAllByTestIdShallow(ReactElement root, String value, {String key: defaultTestIdKey}) {
   Iterable flattenChildren(dynamic children) sync* {
     if (children is Iterable) {
       yield* children.expand(flattenChildren);
@@ -403,6 +427,8 @@ ReactElement _getByTestIdShallow(ReactElement root, String value, {String key: d
       yield children;
     }
   }
+
+  final matchingDescendants = <ReactElement>[];
 
   var breadthFirstDescendants = new Queue()..add(root);
   while (breadthFirstDescendants.isNotEmpty) {
@@ -413,13 +439,13 @@ ReactElement _getByTestIdShallow(ReactElement root, String value, {String key: d
 
     var props = getProps(descendant);
     if (_hasTestId(props, key, value)) {
-      return descendant;
+      matchingDescendants.add(descendant);
     }
 
     breadthFirstDescendants.addAll(flattenChildren(props['children']));
   }
 
-  return null;
+  return matchingDescendants;
 }
 
 /// Returns all descendants of a component that contain the specified prop key.

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -221,22 +221,21 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 ///     var renderedInstance = render(Dom.div()(
 ///         // Div1
-///         (Dom.div()..addTestId('first-div'))()
+///       (Dom.div()..addTestId('first'))(),
 ///
 ///         Dom.div()(
 ///           // Div2
 ///           (Dom.div()
-///             ..addTestId('second-div')
-///             ..addTestId('nested-div')
-///           )()
-///         )
-///       )
-///     );
+///           ..addTestId('second')
+///           ..addTestId('other-id')
+///         )(),
+///       ),
+///     ));
 ///
-///     var firstDiv = getByTestId(renderedInstance, 'first-div'); // Returns Div1
-///     var secondDiv = getByTestId(renderedInstance, 'second-div'); // Returns Div2
-///     var nestedDiv = getByTestId(renderedInstance, 'nested-div'); // Returns Div2
-///     var nonexistentDiv = getByTestId(renderedInstance, 'nonexistent-div'); // Returns null
+///     var first  = getByTestId(renderedInstance, 'first');    // Returns the `Div1` element
+///     var second = getByTestId(renderedInstance, 'second');   // Returns the `Div2` element
+///     var other  = getByTestId(renderedInstance, 'other-id'); // Returns the `Div2` element
+///     var nonexistent = getByTestId(renderedInstance, 'nonexistent'); // Returns `null`
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -249,6 +249,11 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// This is similar to [getByTestId], which returns only the first matching descendant.
 ///
+/// > __Note: when using with components that forward props (like test IDs), this will return both the__
+/// > __Dart components and the components they renders, since they will both have the same test ID.__
+/// >
+/// > If you want to get only Dart components, use [getAllComponentsByTestId].
+///
 /// This method works for:
 ///
 /// * `ReactComponent` render trees (output of [render])
@@ -296,6 +301,32 @@ List/* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defaul
     return _hasTestId(props, key, value);
   }));
 }
+
+/// Similar to [getAllByTestId], but filters out results that aren't Dart components.
+///
+/// This is useful when the Dart component you're targeting forwards props.
+///
+/// For example, given a usage of a component that forwards its props to the rendered DOM:
+///    // Dart Input
+///    (ForwardsProps()
+///      ..addTestId('foo')
+///    )()
+///    // HTML output
+///    '<div class="forwards-props" data-test-id="foo" />'
+///
+///    // This returns [
+///    //   `Instance of 'JsObject'`, (the JS component)
+///    //   `Element:<div class="forwards-props" data-test-id="foo" />`,
+///    // ]
+///    getAllByTestId(root, 'foo')
+///
+///    // This returns [ `<Instance of 'ForwardsPropsComponent'>` ]
+///    getAllComponentsByTestId(root, 'foo')
+List<T> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key: defaultTestIdKey}) =>
+    getAllByTestId(root, value, key: key)
+        .map(getDartComponent)
+        .where((component) => component != null)
+        .toList();
 
 /// Returns the [Element] of the first descendant of [root] that has its [key] prop value set to [value].
 ///

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -17,6 +17,7 @@ import 'dart:html';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:react/react_dom.dart' as react_dom;
+import 'package:react/react_test_utils.dart' as rtu;
 import 'package:test/test.dart';
 
 import './utils/nested_component.dart';
@@ -611,6 +612,71 @@ main() {
 
         var descendants = getAllByTestId(component, 'value');
         expect(descendants, [hasProp('data-name', 'target')]);
+      });
+    });
+
+    group('getAllComponentsByTestId returns only the Dart components with the matching test ID', () {
+      void sharedExpectations(
+        List<dynamic> allByTestId,
+        List<WrapperComponent> allComponentsByTestId,
+      ) {
+        final isCompositeCOmponentMatcher = predicate(rtu.isCompositeComponent, 'is composite component');
+
+        expect(allByTestId, [
+          allOf(hasProp('data-name', 'Wrapper'), isCompositeCOmponentMatcher),
+          // The Wrapper should render a div with the same test ID
+          allOf(hasProp('data-name', 'Wrapper'), const isInstanceOf<Element>()),
+          allOf(hasProp('data-name', 'div'), const isInstanceOf<Element>()),
+          allOf(hasProp('data-name', 'js'), isCompositeCOmponentMatcher),
+        ], reason: 'test setup sanity check');
+
+        expect(allComponentsByTestId, [
+          const isInstanceOf<WrapperComponent>()
+        ]);
+      }
+
+      test('', () {
+        var renderedInstance = render((Wrapper()
+          ..addTestId('foo')
+          ..addProp('data-name', 'Wrapper')
+        )(
+          (Dom.div()
+            ..addTestId('foo')
+            ..addProp('data-name', 'div')
+          )(),
+          testJsComponentFactory(domProps()
+            ..addTestId('foo')
+            ..addProp('data-name', 'js')
+          ),
+        ));
+
+        sharedExpectations(
+          getAllByTestId(renderedInstance, 'foo'),
+          getAllComponentsByTestId<WrapperComponent>(renderedInstance, 'foo'),
+        );
+      });
+
+      test('when a custom test ID is provided', () {
+        const customTestIdKey = 'data-custom-test-id';
+
+        var renderedInstance = render((Wrapper()
+          ..addTestId('foo', key: customTestIdKey)
+          ..addProp('data-name', 'Wrapper')
+        )(
+          (Dom.div()
+            ..addTestId('foo', key: customTestIdKey)
+            ..addProp('data-name', 'div')
+          )(),
+          testJsComponentFactory(domProps()
+            ..addTestId('foo', key: customTestIdKey)
+            ..addProp('data-name', 'js')
+          ),
+        ));
+
+        sharedExpectations(
+          getAllByTestId(renderedInstance, 'foo', key: customTestIdKey),
+          getAllComponentsByTestId<WrapperComponent>(renderedInstance, 'foo', key: customTestIdKey),
+        );
       });
     });
 

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -293,8 +293,8 @@ main() {
           expect(descendant, hasProp('data-name', 'First Descendant'));
         });
 
-        group('the topmost descendant that has the appropriate value for the `data-test-id` prop key when cloned, a testId is added, and then', () {
-          test('the old testId is called', () {
+        group('the topmost descendant that has the appropriate value for the `data-test-id` prop key, an additional testId is added, and then', () {
+          test('the first testId is passed in', () {
             var renderedInstance = testSpecificRender(Wrapper()(
               (Dom.div()
                 ..addTestId('testId1')
@@ -309,7 +309,7 @@ main() {
             expect(descendant, hasProp('data-name', 'Nested Descendant'));
           });
 
-          test('the new testId is called', () {
+          test('the new testId is passed in', () {
             var renderedInstance = testSpecificRender(Wrapper()(
               (Dom.div()
                 ..addTestId('testId1')
@@ -325,8 +325,8 @@ main() {
           });
         });
 
-        group('the topmost descendant that has the appropriate value for a custom prop key when cloned and', () {
-          test('the old testId is called', () {
+        group('the topmost descendant that has the appropriate value for a custom prop key and', () {
+          test('the first testId is passed in', () {
             var renderedInstance = testSpecificRender(Wrapper()(
               (Dom.div()
                 ..addTestId('testId1', key: 'data-custom-id')
@@ -340,7 +340,7 @@ main() {
             expect(descendant, hasProp('data-name', 'Nested Descendant'));
           });
 
-          test('the new testId is called', () {
+          test('the new testId is passed in', () {
             var renderedInstance = testSpecificRender(Wrapper()(
               (Dom.div()
                 ..addTestId('testId1', key: 'data-custom-id')
@@ -503,8 +503,8 @@ main() {
         expect(descendant, getDartComponent(getByTestId(renderedInstance, 'null')));
       });
 
-      group('the topmost react.Component that has the appropriate value for the `data-test-id` prop key when cloned, a testId is added, and', () {
-        test('the old testId is called', () {
+      group('the topmost react.Component that has the appropriate value for the `data-test-id` prop key, an additional testId is added, and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -514,7 +514,7 @@ main() {
           expect(descendant, getDartComponent(getByTestId(renderedInstance, 'testId1')));
         });
 
-        test('the new testId is called', () {
+        test('the new testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -525,8 +525,8 @@ main() {
         });
       });
 
-      group('the topmost react.Component that has the appropriate value for a custom prop key when cloned and', () {
-        test('the old testId is called', () {
+      group('the topmost react.Component that has the appropriate value for a custom prop key and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')
@@ -536,7 +536,7 @@ main() {
           expect(descendant, getDartComponent(getByTestId(renderedInstance, 'testId1', key: 'data-custom-id')));
         });
 
-        test('the old testId is called', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')
@@ -618,8 +618,8 @@ main() {
         expect(descendant, getDartComponent(getByTestId(renderedInstance, 'null')));
       });
 
-      group('the topmost react.Component that has the appropriate value for the `data-test-id` prop key when cloned, a testId is added, and', () {
-        test('the old testId is called', () {
+      group('the topmost react.Component that has the appropriate value for the `data-test-id` prop key, an additional testId is added, and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -629,7 +629,7 @@ main() {
           expect(descendant, getDartComponent(getByTestId(renderedInstance, 'testId1')));
         });
 
-        test('the new testId is called', () {
+        test('the new testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -640,8 +640,8 @@ main() {
         });
       });
 
-      group('the topmost react.Component that has the appropriate value for a custom prop key when cloned and', () {
-        test('the old testId is called', () {
+      group('the topmost react.Component that has the appropriate value for a custom prop key and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')
@@ -651,7 +651,7 @@ main() {
           expect(descendant, getDartComponent(getByTestId(renderedInstance, 'testId1', key: 'data-custom-id')));
         });
 
-        test('the old testId is called', () {
+        test('the first testId is passed in', () {
           var renderedInstance = render((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')
@@ -739,8 +739,8 @@ main() {
         expect(props, equals(getProps(getByTestId(renderedInstance, 'null'))));
       });
 
-      group('the props map of the topmost descendant that has the appropriate value for the `data-test-id` prop key when cloned, a testId is added, and', () {
-        test('the old testId is called', () {
+      group('the props map of the topmost descendant that has the appropriate value for the `data-test-id` prop key, an additional testId is added, and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = ((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -750,7 +750,7 @@ main() {
           expect(props, equals(getProps(getByTestId(renderedInstance, 'testId1'))));
         });
 
-        test('the new testId is called', () {
+        test('the new testId is passed in', () {
           var renderedInstance = ((Test()
             ..addTestId('testId1')
             ..addTestId('testId2')
@@ -761,8 +761,8 @@ main() {
         });
       });
 
-      group('the props map of the topmost descendant that has the appropriate value for a custom prop key when cloned and', () {
-        test('the old testId is called', () {
+      group('the props map of the topmost descendant that has the appropriate value for a custom prop key and', () {
+        test('the first testId is passed in', () {
           var renderedInstance = ((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')
@@ -772,7 +772,7 @@ main() {
           expect(props, equals(getProps(getByTestId(renderedInstance, 'testId1', key: 'data-custom-id'))));
         });
 
-        test('the props map of the topmost descendant that has the appropriate value for a custom prop key when cloned and the new testId is called', () {
+        test('the props map of the topmost descendant that has the appropriate value for a custom prop key and the new testId is passed in', () {
           var renderedInstance = ((Test()
             ..addTestId('testId1', key: 'data-custom-id')
             ..addTestId('testId2', key: 'data-custom-id')

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -403,6 +403,217 @@ main() {
       });
     });
 
+    group('getAllByTestId returns', () {
+      sharedTests({bool shallow}) {
+        testSpecificRender(ReactElement instance) =>
+            shallow ? renderShallow(instance) : render(instance);
+
+        group('a list containing the single descendant that have the appropriate value for the `data-test-id` prop key when it is a', () {
+          const String targetFlagProp = 'data-name';
+
+          const Map testProps = const {
+            'data-test-id': 'value',
+            'data-name': 'target',
+          };
+
+          test('DOM component', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Dom.div()..addProps(testProps))(),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'value');
+            expect(descendants, [hasProp(targetFlagProp, 'target')]);
+          });
+
+          test('Dart component', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Test()..addProps(testProps))(),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'value');
+            expect(descendants, [hasProp(targetFlagProp, 'target')]);
+          });
+
+          test('JS composite component', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              testJsComponentFactory(testProps),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'value');
+            expect(descendants, [hasProp(targetFlagProp, 'target')]);
+          });
+        });
+
+        test('all descendants that have the appropriate value for the `data-test-id` prop key', () {
+          var renderedInstance = testSpecificRender(Wrapper()(
+            (Dom.div()
+              ..addTestId('value')
+              ..addProp('data-name', 'First Descendant')
+            )(),
+            Dom.div()(
+              (Dom.div()
+                ..addTestId('value')
+                ..addProp('data-name', 'Nested Descendant')
+              )(),
+            ),
+          ));
+
+          var descendants = getAllByTestId(renderedInstance, 'value');
+          expect(descendants, [
+            hasProp('data-name', 'First Descendant'),
+            hasProp('data-name', 'Nested Descendant'),
+          ]);
+        });
+
+        test('all descendants that has the appropriate value for the custom prop key', () {
+          var renderedInstance = testSpecificRender(Wrapper()(
+            (Dom.div()
+              ..addTestId('value', key: 'data-custom-id')
+              ..addProp('data-name', 'First Descendant')
+            )(),
+            Dom.div()(
+              (Dom.div()
+                ..addTestId('value', key: 'data-custom-id')
+                ..addProp('data-name', 'Nested Descendant')
+              )(),
+            ),
+          ));
+
+          var descendants = getAllByTestId(renderedInstance, 'value', key: 'data-custom-id');
+          expect(descendants, [
+            hasProp('data-name', 'First Descendant'),
+            hasProp('data-name', 'Nested Descendant'),
+          ]);
+        });
+
+        test('the topmost descendant that has the `data-test-id` prop set to \'null\' when the user searches for \'null\'', () {
+          var renderedInstance = testSpecificRender(Wrapper()(
+            (Dom.div()
+              ..addTestId('null')
+              ..addProp('data-name', 'First Descendant')
+            )(),
+            Dom.div()(
+              (Dom.div()
+                ..addTestId('null')
+                ..addProp('data-name', 'Nested Descendant')
+              )(),
+            ),
+          ));
+
+          var descendants = getAllByTestId(renderedInstance, 'null');
+          expect(descendants, [
+            hasProp('data-name', 'First Descendant'),
+            hasProp('data-name', 'Nested Descendant'),
+          ]);
+        });
+
+        group('the topmost descendant that has the appropriate value for the `data-test-id` prop key, an additional testId is added, and then', () {
+          test('the first testId is passed in', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Dom.div()
+                ..addTestId('testId1')
+                ..addTestId('testId2')
+                ..addProp('data-name', 'Nested Descendant')
+              )(
+                Dom.div()('Nested Descendant 2'),
+              ),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'testId1');
+            expect(descendants, [hasProp('data-name', 'Nested Descendant')]);
+          });
+
+          test('the new testId is passed in', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Dom.div()
+                ..addTestId('testId1')
+                ..addTestId('testId2')
+                ..addProp('data-name', 'Nested Descendant')
+              )(
+                Dom.div()('Nested Descendant 2'),
+              ),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'testId2');
+            expect(descendants, [hasProp('data-name', 'Nested Descendant')]);
+          });
+        });
+
+        group('the topmost descendant that has the appropriate value for a custom prop key and', () {
+          test('the first testId is passed in', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Dom.div()
+                ..addTestId('testId1', key: 'data-custom-id')
+                ..addTestId('testId2', key: 'data-custom-id')
+                ..addProp('data-name', 'Nested Descendant')
+              )(),
+              Dom.div()('Nested Descendant 2'),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'testId1', key: 'data-custom-id');
+            expect(descendants, [hasProp('data-name', 'Nested Descendant')]);
+          });
+
+          test('the new testId is passed in', () {
+            var renderedInstance = testSpecificRender(Wrapper()(
+              (Dom.div()
+                ..addTestId('testId1', key: 'data-custom-id')
+                ..addTestId('testId2', key: 'data-custom-id')
+                ..addProp('data-name', 'Nested Descendant')
+              )(),
+              Dom.div()('Nested Descendant 2'),
+            ));
+
+            var descendants = getAllByTestId(renderedInstance, 'testId2', key: 'data-custom-id');
+            expect(descendants, [hasProp('data-name', 'Nested Descendant')]);
+          });
+        });
+
+        test('an empty list if no descendant has the appropriate value for the `data-test-id` prop key', () {
+          var renderedInstance = testSpecificRender(Wrapper()());
+
+          var descendants = getAllByTestId(renderedInstance, 'value');
+          expect(descendants, isEmpty);
+        });
+
+        test('an empty list if the user searches for a test ID of \'null\' when no test ID is set', () {
+          var renderedInstance = testSpecificRender(Wrapper()());
+
+          var descendants = getAllByTestId(renderedInstance, 'null');
+          expect(descendants, isEmpty);
+        });
+
+        test('an empty list if the user searches for a test ID of `null` when the test ID is set to \'null\'', () {
+          var renderedInstance = testSpecificRender(Wrapper()(
+            (Test()..addTestId('null'))(),
+          ));
+
+          var descendants = getAllByTestId(renderedInstance, null);
+          expect(descendants, isEmpty);
+        });
+      }
+
+      group('(rendered component)', () {
+        sharedTests(shallow: false);
+      });
+
+      group('(shallow-rendered component)', () {
+        sharedTests(shallow: true);
+      });
+
+      test('returns correctly when passed a react.Component', () {
+        var component = renderAndGetComponent(Wrapper()(
+          (Test()
+            ..addTestId('value')
+            ..addProp('data-name', 'target')
+          )(),
+        ));
+
+        var descendants = getAllByTestId(component, 'value');
+        expect(descendants, [hasProp('data-name', 'target')]);
+      });
+    });
+
     group('queryByTestId returns the topmost Element that has the appropriate value for the', () {
       group('`data-test-id` html attribute key', () {
         test('', () {


### PR DESCRIPTION
## Ultimate problem:
Consumers wanted a function like `getByTestId` that look up React components by their test IDs, but returns all results instead of at most one.

## How it was fixed:
- Add `getAllByTestId`/`getAllComponentsByTestId`
- Add tests (copypasta'd and adapted from `getByTestId` tests)

Boyscouting:
- Update some bad test descriptions
- Update doc comment for `getByTestId`

## QA +1 instructions:
- Verify CI passes
- Verify this works for the consumer use-case

## Potential areas of regression:
- `getByTestId`

