### PR TITLE
AF-3525: Update component boilerplate for Dart 1/2

### DIFF
--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -194,7 +194,7 @@ void testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
       if (ignoreDomProps) {
         // Remove DomProps because they should be forwarded.
-        const $PropKeys(DomPropsMixin).forEach(propsThatShouldNotGetForwarded.remove);
+        DomPropsMixin.meta.keys.forEach(propsThatShouldNotGetForwarded.remove);
       }
 
     var shallowRenderer = react_test_utils.createRenderer();

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -22,7 +22,7 @@ import 'dart:html';
 import 'dart:mirrors';
 
 import 'package:over_react/over_react.dart'
-    show $PropKeys, BuilderOnlyUiFactory, ConsumedProps, CssClassPropsMixin, DomPropsMixin, DomProps,
+    show BuilderOnlyUiFactory, ConsumedProps, CssClassPropsMixin, DomPropsMixin, DomProps,
          PropDescriptor, ReactPropsMixin, UbiquitousDomPropsMixin, unindent, requiredProp, defaultTestIdKey;
 import 'package:over_react/component_base.dart' as component_base;
 import 'package:over_react_test/over_react_test.dart';

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -161,8 +161,8 @@ class _HasPropMatcher extends CustomMatcher {
   static bool _useDomAttributes(item) => react_test_utils.isDOMComponent(item);
 
   static bool _isValidDomPropKey(propKey) => (
-      const $PropKeys(DomPropsMixin).contains(propKey) ||
-      const $PropKeys(SvgPropsMixin).contains(propKey) ||
+      DomPropsMixin.meta.keys.contains(propKey) ||
+      SvgPropsMixin.meta.keys.contains(propKey) ||
       (propKey is String && (
           propKey.startsWith('data-') ||
           propKey.startsWith('aria-'))

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -14,17 +14,28 @@
 
 import 'package:over_react/over_react.dart';
 
+// ignore: uri_has_not_been_generated
+part 'wrapper_component.over_react.g.dart';
+
 /// A helper component for use in tests where a component needs to be
 /// rendered inside a wrapper, but a composite component must be used
 /// for compatability with `getByTestId()`.
 @Factory()
-UiFactory<UiProps> Wrapper;
+// ignore: undefined_identifier
+UiFactory<UiProps> Wrapper = $Wrapper;
 
 @Props()
-class WrapperProps extends UiProps {}
+class _$WrapperProps extends UiProps {}
 
 @Component()
 class WrapperComponent extends UiComponent<WrapperProps> {
   @override
   render() => (Dom.div()..addAll(props))(props.children);
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class WrapperProps extends _$WrapperProps with _$WrapperPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForWrapperProps;
 }

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -25,7 +25,7 @@ main() {
     // TODO: Improve / expand upon these tests.
     group('should pass when the correct unconsumed props are specified', () {
       commonComponentTests(TestCommon, unconsumedPropKeys: [
-        const $PropKeys(PropsThatShouldBeForwarded),
+        PropsThatShouldBeForwarded.meta.keys,
       ]);
     });
 

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -18,6 +18,9 @@ import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
 import 'package:over_react_test/over_react_test.dart';
 
+// ignore: uri_has_not_been_generated
+part 'jacket_test.over_react.g.dart';
+
 /// Main entry point for TestJacket testing
 main() {
   group('mount: renders the given instance', () {
@@ -208,15 +211,16 @@ main() {
 }
 
 @Factory()
-UiFactory<SampleProps> Sample;
+// ignore: undefined_identifier
+UiFactory<SampleProps> Sample = $Sample;
 
 @Props()
-class SampleProps extends UiProps {
+class _$SampleProps extends UiProps {
   bool foo;
 }
 
 @State()
-class SampleState extends UiState {
+class _$SampleState extends UiState {
   bool bar;
 }
 
@@ -232,4 +236,18 @@ class SampleComponent extends UiStatefulComponent<SampleProps, SampleState> {
   render() {
     return Dom.div()();
   }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class SampleProps extends _$SampleProps with _$SamplePropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForSampleProps;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class SampleState extends _$SampleState with _$SampleStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = $metaForSampleState;
 }

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -22,6 +22,9 @@ import 'package:test/test.dart';
 
 import './utils/nested_component.dart';
 
+// ignore: uri_has_not_been_generated
+part 'react_util_test.over_react.g.dart';
+
 /// Main entry point for ReactUtil testing
 main() {
   group('ReactUtil', () {
@@ -1172,13 +1175,21 @@ main() {
 }
 
 @Factory()
-UiFactory<TestProps> Test;
+// ignore: undefined_identifier
+UiFactory<TestProps> Test = $Test;
 
 @Props()
-class TestProps extends UiProps {}
+class _$TestProps extends UiProps {}
 
 @Component()
 class TestComponent extends UiComponent<TestProps> {
   @override
   render() => (Dom.div()..addProp('isRenderResult', true))();
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForTestProps;
 }

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -14,11 +14,15 @@
 
 import 'package:over_react/over_react.dart';
 
+// ignore: uri_has_not_been_generated
+part 'nested_component.over_react.g.dart';
+
 @Factory()
-UiFactory<NestedProps> Nested;
+// ignore: undefined_identifier
+UiFactory<NestedProps> Nested = $Nested;
 
 @Props()
-class NestedProps extends UiProps {}
+class _$NestedProps extends UiProps {}
 
 @Component()
 class NestedComponent extends UiComponent<NestedProps> {
@@ -31,4 +35,11 @@ class NestedComponent extends UiComponent<NestedProps> {
       )()
     );
   }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class NestedProps extends _$NestedProps with _$NestedPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForNestedProps;
 }

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -16,18 +16,22 @@ import 'package:over_react/over_react.dart';
 
 import './test_common_component_nested.dart';
 
+// ignore: uri_has_not_been_generated
+part 'test_common_component.over_react.g.dart';
+
 @Factory()
-UiFactory<TestCommonProps> TestCommon;
+// ignore: undefined_identifier
+UiFactory<TestCommonProps> TestCommon = $TestCommon;
 
 @Props()
-class TestCommonProps extends UiProps with PropsThatShouldBeForwarded, PropsThatShouldNotBeForwarded {}
+class _$TestCommonProps extends UiProps with PropsThatShouldBeForwarded, PropsThatShouldNotBeForwarded {}
 
 @Component(subtypeOf: TestCommonNestedComponent)
 class TestCommonComponent extends UiComponent<TestCommonProps> {
   @override
   get consumedProps => const [
-    const $Props(TestCommonProps),
-    const $Props(PropsThatShouldNotBeForwarded)
+    TestCommonProps.meta,
+    PropsThatShouldNotBeForwarded.meta
   ];
 
   @override
@@ -41,6 +45,11 @@ class TestCommonComponent extends UiComponent<TestCommonProps> {
 
 @PropsMixin()
 abstract class PropsThatShouldBeForwarded {
+  // To ensure the codemod regression checking works properly, please keep this
+  // field at the top of the class!
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForPropsThatShouldBeForwarded;
+
   Map get props;
 
   bool foo;
@@ -48,7 +57,19 @@ abstract class PropsThatShouldBeForwarded {
 
 @PropsMixin()
 abstract class PropsThatShouldNotBeForwarded {
+  // To ensure the codemod regression checking works properly, please keep this
+  // field at the top of the class!
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForPropsThatShouldNotBeForwarded;
+
   Map get props;
 
   bool bar;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestCommonProps extends _$TestCommonProps with _$TestCommonPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForTestCommonProps;
 }

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -24,7 +24,13 @@ part 'test_common_component.over_react.g.dart';
 UiFactory<TestCommonProps> TestCommon = $TestCommon;
 
 @Props()
-class _$TestCommonProps extends UiProps with PropsThatShouldBeForwarded, PropsThatShouldNotBeForwarded {}
+class _$TestCommonProps extends UiProps with
+    PropsThatShouldBeForwarded,
+    // ignore: mixin_of_non_class, undefined_class
+    $PropsThatShouldBeForwarded,
+    PropsThatShouldNotBeForwarded,
+    // ignore: mixin_of_non_class, undefined_class
+    $PropsThatShouldNotBeForwarded {}
 
 @Component(subtypeOf: TestCommonNestedComponent)
 class TestCommonComponent extends UiComponent<TestCommonProps> {

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -17,11 +17,15 @@ import 'package:over_react/over_react.dart';
 import './test_common_component.dart';
 import './test_common_component_nested2.dart';
 
+// ignore: uri_has_not_been_generated
+part 'test_common_component_nested.over_react.g.dart';
+
 @Factory()
-UiFactory<TestCommonNestedProps> TestCommonNested;
+// ignore: undefined_identifier
+UiFactory<TestCommonNestedProps> TestCommonNested = $TestCommonNested;
 
 @Props()
-class TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}
+class _$TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}
 
 @Component()
 class TestCommonNestedComponent extends UiComponent<TestCommonNestedProps> {
@@ -31,4 +35,11 @@ class TestCommonNestedComponent extends UiComponent<TestCommonNestedProps> {
       ..addProps(copyUnconsumedProps())
     )(props.children);
   }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestCommonNestedProps extends _$TestCommonNestedProps with _$TestCommonNestedPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForTestCommonNestedProps;
 }

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -14,11 +14,15 @@
 
 import 'package:over_react/over_react.dart';
 
+// ignore: uri_has_not_been_generated
+part 'test_common_component_nested2.over_react.g.dart';
+
 @Factory()
-UiFactory<TestCommonNested2Props> TestCommonNested2;
+// ignore: undefined_identifier
+UiFactory<TestCommonNested2Props> TestCommonNested2 = $TestCommonNested2;
 
 @Props()
-class TestCommonNested2Props extends UiProps {}
+class _$TestCommonNested2Props extends UiProps {}
 
 @Component()
 class TestCommonNested2Component extends UiComponent<TestCommonNested2Props> {
@@ -28,4 +32,11 @@ class TestCommonNested2Component extends UiComponent<TestCommonNested2Props> {
       ..addProps(copyUnconsumedDomProps())
     )(props.children);
   }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestCommonNested2Props extends _$TestCommonNested2Props with _$TestCommonNested2PropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForTestCommonNested2Props;
 }

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -14,11 +14,15 @@
 
 import 'package:over_react/over_react.dart';
 
+// ignore: uri_has_not_been_generated
+part 'test_common_component_required_props.over_react.g.dart';
+
 @Factory()
-UiFactory<TestCommonRequiredProps> TestCommonRequired;
+// ignore: undefined_identifier
+UiFactory<TestCommonRequiredProps> TestCommonRequired = $TestCommonRequired;
 
 @Props()
-class TestCommonRequiredProps extends UiProps {
+class _$TestCommonRequiredProps extends UiProps {
   @requiredProp
   bool bar;
 }
@@ -27,7 +31,7 @@ class TestCommonRequiredProps extends UiProps {
 class TestCommonRequiredComponent extends UiComponent<TestCommonRequiredProps> {
   @override
   get consumedProps => const [
-    const $Props(TestCommonRequiredProps),
+    TestCommonRequiredProps.meta,
   ];
 
   @override
@@ -36,4 +40,11 @@ class TestCommonRequiredComponent extends UiComponent<TestCommonRequiredProps> {
       ..addProps(copyUnconsumedDomProps())
     )(props.children);
   }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestCommonRequiredProps extends _$TestCommonRequiredProps with _$TestCommonRequiredPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForTestCommonRequiredProps;
 }


### PR DESCRIPTION
## Ultimate problem:
Need updated boilerplate for Dart 1/2 compatibility.

## How it was fixed:
* Run the over_react_codemod script and update components with new boilerplate
* Fix class declaration using some mixins which were not picked up by codemod

## Testing suggestions:
* CI Passes

## Potential areas of regression:
None

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @joelleibow-wf @evanweible-wf @sebastianmalysa-wf @robbecker-wf
