### PR TITLE
AF-3567: Dart 2 compatibility (almost!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev analyze
-  - pub run dependency_validator -i coverage, build_runner, build_test, build_web_compilers
+  - pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers
   - pub run dart_dev test
   - ./tool/generate_coverage.sh
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev analyze
-  - pub run dependency_validator -i coverage
+  - pub run dependency_validator -i coverage, build_runner, build_test, build_web_compilers
   - pub run dart_dev test
   - ./tool/generate_coverage.sh
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ADD . /build/
 RUN echo "Starting the script sections" && \
 		dart --version && \
 		pub get && \
-        pub run dependency_validator -i coverage && \
+				pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers && \
 		echo "Script sections completed"
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ADD . /build/
 RUN echo "Starting the script sections" && \
 		dart --version && \
 		pub get && \
-				pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers && \
+		pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers && \
 		echo "Script sections completed"
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -14,11 +14,6 @@
 
 import 'dart:collection';
 import 'dart:html';
-// Tell dart2js that this library only needs to reflect types annotated with `Props`.
-// This speeds up compilation and makes JS output much smaller.
-//@MirrorsUsed(metaTargets: const [
-//  'over_react.component_declaration.annotations.Props'
-//])
 
 import 'package:over_react/over_react.dart'
     show BuilderOnlyUiFactory, ConsumedProps, CssClassPropsMixin, DomPropsMixin, DomProps,
@@ -95,14 +90,15 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   unconsumedPropKeys = flatten(unconsumedPropKeys).toList();
   skippedPropKeys = flatten(skippedPropKeys).toList();
 
-  if (shouldTestPropForwarding) {
-    testPropForwarding(factory, childrenFactory,
-        unconsumedPropKeys: unconsumedPropKeys,
-        ignoreDomProps: ignoreDomProps,
-        skippedPropKeys: skippedPropKeys,
-        nonDefaultForwardingTestProps: nonDefaultForwardingTestProps
-    );
-  }
+// TODO: Uncomment this as part of AF-3700: https://jira.atl.workiva.net/browse/AF-3700
+//  if (shouldTestPropForwarding) {
+//    testPropForwarding(factory, childrenFactory,
+//        unconsumedPropKeys: unconsumedPropKeys,
+//        ignoreDomProps: ignoreDomProps,
+//        skippedPropKeys: skippedPropKeys,
+//        nonDefaultForwardingTestProps: nonDefaultForwardingTestProps
+//    );
+//  }
   if (shouldTestClassNameMerging) {
     testClassNameMerging(factory, childrenFactory);
   }
@@ -150,142 +146,144 @@ void expectCleanTestSurfaceAtEnd() {
 /// Common test for verifying that unconsumed props are forwarded as expected.
 ///
 /// > Typically not consumed standalone. Use [commonComponentTests] instead.
-void testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory(), {
-    List unconsumedPropKeys: const [],
-    bool ignoreDomProps: true,
-    List skippedPropKeys: const [],
-    Map nonDefaultForwardingTestProps: const {}
-}) {
-  test('forwards unconsumed props as expected', () {
-    const Map extraProps = const {
-      // Add this so we find the right component(s) with [getForwardingTargets] later.
-      forwardedPropBeacon: true,
-
-      'data-true': true,
-      'aria-true': true,
-
-      'data-null': null,
-      'aria-null': null
-    };
-
-    const Map otherProps = const {
-      'other-true': true,
-      'other-null': null
-    };
-
-    const String testId = 'testIdThatShouldBeForwarded';
-
-    const String key = 'testKeyThatShouldNotBeForwarded';
-    const String ref = 'testRefThatShouldNotBeForwarded';
-
-    /// Get defaults from a ReactElement to account for default props and any props added by the factory.
-    Map defaultProps = new Map.from(getProps(factory()()))
-      ..remove('children');
-
-    // TODO: Account for alias components.
-    Map propsThatShouldNotGetForwarded = {}
-      ..addAll(new Map.fromIterable(getComponentPropKeys(factory), value: (_) => null))
-      // Add defaults afterwards so that components don't blow up when they have unexpected null props.
-      ..addAll(defaultProps)
-      ..addAll(nonDefaultForwardingTestProps);
-
-      unconsumedPropKeys.forEach(propsThatShouldNotGetForwarded.remove);
-
-      if (ignoreDomProps) {
-        // Remove DomProps because they should be forwarded.
-        DomPropsMixin.meta.keys.forEach(propsThatShouldNotGetForwarded.remove);
-      }
-
-    var shallowRenderer = react_test_utils.createRenderer();
-
-    var instance = (factory()
-      ..addProps(propsThatShouldNotGetForwarded)
-      ..addProps(extraProps)
-      ..addProps(otherProps)
-      ..addTestId(testId)
-      ..key = key
-      ..ref = ref
-    )(childrenFactory());
-
-    shallowRenderer.render(instance);
-    var result = shallowRenderer.getRenderOutput();
-
-    var forwardingTargets = getForwardingTargets(result, shallowRendered: true);
-
-    for (var forwardingTarget in forwardingTargets) {
-      Map actualProps = getProps(forwardingTarget);
-
-      // If the forwarding target is a DOM element it will should not have invalid DOM props forwarded to it.
-      if (isDomElement(forwardingTarget)) {
-        otherProps.forEach((key, value) {
-          expect(actualProps, isNot(containsPair(key, value)));
-        });
-      } else {
-        otherProps.forEach((key, value) {
-          expect(actualProps, containsPair(key, value));
-        });
-      }
-
-      // Expect the target to have all forwarded props.
-      extraProps.forEach((key, value) {
-        expect(actualProps, containsPair(key, value));
-      });
-
-      // Check that the added testId is part of the final testId string.
-      expect(actualProps[defaultTestIdKey], contains(testId),
-          reason: '$defaultTestIdKey was not forwarded or was forwarded and then overridden.');
-
-      var ambiguousProps = {};
-
-      Set propKeysThatShouldNotGetForwarded = propsThatShouldNotGetForwarded.keys.toSet();
-      // Don't test any keys specified by skippedPropKeys.
-      propKeysThatShouldNotGetForwarded.removeAll(skippedPropKeys);
-
-      Set unexpectedKeys = actualProps.keys.toSet().intersection(propKeysThatShouldNotGetForwarded);
-
-      /// Test for prop keys that both are forwarded and exist on the forwarding target's default props.
-      if (isDartComponent(forwardingTarget)) {
-        // ignore: avoid_as
-        var forwardingTargetDefaults = ((forwardingTarget as ReactElement).type as ReactClass).dartDefaultProps;
-
-        var commonForwardedAndDefaults = propKeysThatShouldNotGetForwarded
-            .intersection(forwardingTargetDefaults.keys.toSet());
-
-        /// Don't count these as unexpected keys in later assertions; we'll verify them within this block.
-        unexpectedKeys.removeAll(commonForwardedAndDefaults);
-
-        commonForwardedAndDefaults.forEach((propKey) {
-          var defaultTargetValue = forwardingTargetDefaults[propKey];
-          var potentiallyForwardedValue = propsThatShouldNotGetForwarded[propKey];
-
-          if (defaultTargetValue != potentiallyForwardedValue) {
-            /// If the potentially forwarded value and the default are different,
-            /// we can tell whether it was forwarded.
-            expect(actualProps, isNot(containsPair(propKey, potentiallyForwardedValue)),
-                reason: 'The `$propKey` prop was forwarded when it should not have been');
-          } else {
-            /// ...otherwise, we can't be certain that the value isn't being forwarded.
-            ambiguousProps[propKey] = defaultTargetValue;
-          }
-        });
-      }
-
-      expect(unexpectedKeys, isEmpty, reason: 'Should filter out all consumed props');
-
-      if (ambiguousProps.isNotEmpty) {
-        fail(unindent(
-            '''
-            Encountered ambiguous forwarded props; some unconsumed props coincide with defaults on the forwarding target, and cannot be automatically tested.
-
-            Try either:
-              - specifying `nonDefaultForwardingTestProps` as a Map with valid prop values that are different than the following: $ambiguousProps
-              - specifying `skippedPropKeys` with the following prop keys and testing their forwarding manually: ${ambiguousProps.keys.toList()}
-            '''
-        ));
-      }
-    }
-  });
-}
+///
+// TODO: Uncomment this as part of AF-3700: https://jira.atl.workiva.net/browse/AF-3700
+//void testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory(), {
+//    List unconsumedPropKeys: const [],
+//    bool ignoreDomProps: true,
+//    List skippedPropKeys: const [],
+//    Map nonDefaultForwardingTestProps: const {}
+//}) {
+//  test('forwards unconsumed props as expected', () {
+//    const Map extraProps = const {
+//      // Add this so we find the right component(s) with [getForwardingTargets] later.
+//      forwardedPropBeacon: true,
+//
+//      'data-true': true,
+//      'aria-true': true,
+//
+//      'data-null': null,
+//      'aria-null': null
+//    };
+//
+//    const Map otherProps = const {
+//      'other-true': true,
+//      'other-null': null
+//    };
+//
+//    const String testId = 'testIdThatShouldBeForwarded';
+//
+//    const String key = 'testKeyThatShouldNotBeForwarded';
+//    const String ref = 'testRefThatShouldNotBeForwarded';
+//
+//    /// Get defaults from a ReactElement to account for default props and any props added by the factory.
+//    Map defaultProps = new Map.from(getProps(factory()()))
+//      ..remove('children');
+//
+//    // TODO: Account for alias components.
+//    Map propsThatShouldNotGetForwarded = {}
+//      ..addAll(new Map.fromIterable(getComponentPropKeys(factory), value: (_) => null))
+//      // Add defaults afterwards so that components don't blow up when they have unexpected null props.
+//      ..addAll(defaultProps)
+//      ..addAll(nonDefaultForwardingTestProps);
+//
+//      unconsumedPropKeys.forEach(propsThatShouldNotGetForwarded.remove);
+//
+//      if (ignoreDomProps) {
+//        // Remove DomProps because they should be forwarded.
+//        DomPropsMixin.meta.keys.forEach(propsThatShouldNotGetForwarded.remove);
+//      }
+//
+//    var shallowRenderer = react_test_utils.createRenderer();
+//
+//    var instance = (factory()
+//      ..addProps(propsThatShouldNotGetForwarded)
+//      ..addProps(extraProps)
+//      ..addProps(otherProps)
+//      ..addTestId(testId)
+//      ..key = key
+//      ..ref = ref
+//    )(childrenFactory());
+//
+//    shallowRenderer.render(instance);
+//    var result = shallowRenderer.getRenderOutput();
+//
+//    var forwardingTargets = getForwardingTargets(result, shallowRendered: true);
+//
+//    for (var forwardingTarget in forwardingTargets) {
+//      Map actualProps = getProps(forwardingTarget);
+//
+//      // If the forwarding target is a DOM element it will should not have invalid DOM props forwarded to it.
+//      if (isDomElement(forwardingTarget)) {
+//        otherProps.forEach((key, value) {
+//          expect(actualProps, isNot(containsPair(key, value)));
+//        });
+//      } else {
+//        otherProps.forEach((key, value) {
+//          expect(actualProps, containsPair(key, value));
+//        });
+//      }
+//
+//      // Expect the target to have all forwarded props.
+//      extraProps.forEach((key, value) {
+//        expect(actualProps, containsPair(key, value));
+//      });
+//
+//      // Check that the added testId is part of the final testId string.
+//      expect(actualProps[defaultTestIdKey], contains(testId),
+//          reason: '$defaultTestIdKey was not forwarded or was forwarded and then overridden.');
+//
+//      var ambiguousProps = {};
+//
+//      Set propKeysThatShouldNotGetForwarded = propsThatShouldNotGetForwarded.keys.toSet();
+//      // Don't test any keys specified by skippedPropKeys.
+//      propKeysThatShouldNotGetForwarded.removeAll(skippedPropKeys);
+//
+//      Set unexpectedKeys = actualProps.keys.toSet().intersection(propKeysThatShouldNotGetForwarded);
+//
+//      /// Test for prop keys that both are forwarded and exist on the forwarding target's default props.
+//      if (isDartComponent(forwardingTarget)) {
+//        // ignore: avoid_as
+//        var forwardingTargetDefaults = ((forwardingTarget as ReactElement).type as ReactClass).dartDefaultProps;
+//
+//        var commonForwardedAndDefaults = propKeysThatShouldNotGetForwarded
+//            .intersection(forwardingTargetDefaults.keys.toSet());
+//
+//        /// Don't count these as unexpected keys in later assertions; we'll verify them within this block.
+//        unexpectedKeys.removeAll(commonForwardedAndDefaults);
+//
+//        commonForwardedAndDefaults.forEach((propKey) {
+//          var defaultTargetValue = forwardingTargetDefaults[propKey];
+//          var potentiallyForwardedValue = propsThatShouldNotGetForwarded[propKey];
+//
+//          if (defaultTargetValue != potentiallyForwardedValue) {
+//            /// If the potentially forwarded value and the default are different,
+//            /// we can tell whether it was forwarded.
+//            expect(actualProps, isNot(containsPair(propKey, potentiallyForwardedValue)),
+//                reason: 'The `$propKey` prop was forwarded when it should not have been');
+//          } else {
+//            /// ...otherwise, we can't be certain that the value isn't being forwarded.
+//            ambiguousProps[propKey] = defaultTargetValue;
+//          }
+//        });
+//      }
+//
+//      expect(unexpectedKeys, isEmpty, reason: 'Should filter out all consumed props');
+//
+//      if (ambiguousProps.isNotEmpty) {
+//        fail(unindent(
+//            '''
+//            Encountered ambiguous forwarded props; some unconsumed props coincide with defaults on the forwarding target, and cannot be automatically tested.
+//
+//            Try either:
+//              - specifying `nonDefaultForwardingTestProps` as a Map with valid prop values that are different than the following: $ambiguousProps
+//              - specifying `skippedPropKeys` with the following prop keys and testing their forwarding manually: ${ambiguousProps.keys.toList()}
+//            '''
+//        ));
+//      }
+//    }
+//  });
+//}
 
 /// Common test for verifying that [DomProps.className]s are merged/blacklisted as expected.
 ///
@@ -452,8 +450,10 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
 // ********************************************************
 
 /// Returns all the keys found within `props` on a component definition, using reflection.
-Set getComponentPropKeys(BuilderOnlyUiFactory factory) {
-  var definition = factory();
+///
+// TODO: Uncomment this as part of AF-3700: https://jira.atl.workiva.net/browse/AF-3700
+//Set getComponentPropKeys(BuilderOnlyUiFactory factory) {
+//  var definition = factory();
 //  InstanceMirror definitionMirror = reflect(definition);
 //
 //  Map<Symbol, MethodMirror> members;
@@ -491,9 +491,9 @@ Set getComponentPropKeys(BuilderOnlyUiFactory factory) {
 //      } catch(_) {}
 //    }
 //  });
-
-  return definition.keys.toSet();
-}
+//
+//  return definition.keys.toSet();
+//}
 
 /// Return the components to which `props` have been forwarded.
 ///

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -16,10 +16,9 @@ import 'dart:collection';
 import 'dart:html';
 // Tell dart2js that this library only needs to reflect types annotated with `Props`.
 // This speeds up compilation and makes JS output much smaller.
-@MirrorsUsed(metaTargets: const [
-  'over_react.component_declaration.annotations.Props'
-])
-import 'dart:mirrors';
+//@MirrorsUsed(metaTargets: const [
+//  'over_react.component_declaration.annotations.Props'
+//])
 
 import 'package:over_react/over_react.dart'
     show BuilderOnlyUiFactory, ConsumedProps, CssClassPropsMixin, DomPropsMixin, DomProps,
@@ -455,43 +454,43 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
 /// Returns all the keys found within `props` on a component definition, using reflection.
 Set getComponentPropKeys(BuilderOnlyUiFactory factory) {
   var definition = factory();
-  InstanceMirror definitionMirror = reflect(definition);
-
-  Map<Symbol, MethodMirror> members;
-
-  // instanceMembers is not implemented for the DDC and will throw is this test is loaded even if it's not run.
-  try {
-    members = definitionMirror.type.instanceMembers;
-  } catch(e) {
-    members = {};
-  }
-
-  // Use prop getters on the props class to infer the prop keys for the component.
-  // Set all props to null to create key-value pairs for each prop, and then return those keys.
-  members.values.forEach((MethodMirror decl) {
-    // Filter out all members except concrete instance getters.
-    if (!decl.isGetter || decl.isSynthetic || decl.isStatic) {
-      return;
-    }
-
-    Type owner = (decl.owner as ClassMirror).reflectedType;
-    if (owner != Object &&
-        owner != component_base.UiProps &&
-        owner != component_base.PropsMapViewMixin &&
-        owner != component_base.MapViewMixin &&
-        owner != MapView &&
-        owner != ReactPropsMixin &&
-        owner != DomPropsMixin &&
-        owner != CssClassPropsMixin &&
-        owner != UbiquitousDomPropsMixin
-    ) {
-      // Some of the getters won't correspond to props, and won't have setters.
-      // Catch resultant exceptions and move on.
-      try {
-        definitionMirror.setField(decl.simpleName, null);
-      } catch(_) {}
-    }
-  });
+//  InstanceMirror definitionMirror = reflect(definition);
+//
+//  Map<Symbol, MethodMirror> members;
+//
+//  // instanceMembers is not implemented for the DDC and will throw is this test is loaded even if it's not run.
+//  try {
+//    members = definitionMirror.type.instanceMembers;
+//  } catch(e) {
+//    members = {};
+//  }
+//
+//  // Use prop getters on the props class to infer the prop keys for the component.
+//  // Set all props to null to create key-value pairs for each prop, and then return those keys.
+//  members.values.forEach((MethodMirror decl) {
+//    // Filter out all members except concrete instance getters.
+//    if (!decl.isGetter || decl.isSynthetic || decl.isStatic) {
+//      return;
+//    }
+//
+//    Type owner = (decl.owner as ClassMirror).reflectedType;
+//    if (owner != Object &&
+//        owner != component_base.UiProps &&
+//        owner != component_base.PropsMapViewMixin &&
+//        owner != component_base.MapViewMixin &&
+//        owner != MapView &&
+//        owner != ReactPropsMixin &&
+//        owner != DomPropsMixin &&
+//        owner != CssClassPropsMixin &&
+//        owner != UbiquitousDomPropsMixin
+//    ) {
+//      // Some of the getters won't correspond to props, and won't have setters.
+//      // Catch resultant exceptions and move on.
+//      try {
+//        definitionMirror.setField(decl.simpleName, null);
+//      } catch(_) {}
+//    }
+//  });
 
   return definition.keys.toSet();
 }

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -324,7 +324,7 @@ List/* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defaul
 ///    getAllComponentsByTestId(root, 'foo')
 List<T> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key: defaultTestIdKey}) =>
     getAllByTestId(root, value, key: key)
-        .map(getDartComponent)
+        .map((element) => getDartComponent<T>(element)) // ignore: unnecessary_lambdas
         .where((component) => component != null)
         .toList();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   js: ^0.6.1
   matcher: ^0.12.1+4
-  over_react: ^1.25.0
+  over_react: ^1.30.0
   react: ">=3.7.0 <5.0.0"
   test: ">=0.12.32+1 <2.0.0"
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,28 @@ dependencies:
   react: ">=3.7.0 <5.0.0"
   test: any #^0.12.32+1
 dev_dependencies:
-  coverage: ">=0.7.2 <0.11.0"
-  dart_dev: ^1.9.6
-  dependency_validator: ^1.2.2
-transformers:
-  - over_react
-  - test/pub_serve:
-      $include: test/**_test{.*,}.dart
+  build_runner: any #^0.10.0
+  coverage: ">=0.10.0 <0.12.4"
+  dart_dev: ">=1.7.7 <3.0.0"
+  dependency_validator: ^1.1.0
+  build_test: any
+  build_web_compilers: any
+  transformer_utils: any
+#transformers:
+#  - over_react
+#  - test/pub_serve:
+#      $include: test/**_test{.*,}.dart
+
+dependency_overrides:
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: ca45e3783180d6a928ad7d38145b4e66a388b2f7 # from builder_generate_public_class
+  transformer_utils:
+    git:
+      url: git@github.com:workiva/dart_transformer_utils.git
+      ref: cc2200ab8e6fb408899b64e53b4aedb0ac69ca5f # from dart2_compat
+  built_redux:
+    git:
+      url: git@github.com:corwinsheahan-wf/built_redux.git
+      ref: 9c9580242e8af6b905ef26c452600dca2195a98b # from bump_build_runner

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,22 +11,16 @@ dependencies:
   matcher: ^0.12.1+4
   over_react: ^1.25.0
   react: ">=3.7.0 <5.0.0"
-  test: any #^0.12.32+1
+  test: ">=0.12.32+1 <2.0.0"
 dev_dependencies:
-  build_runner: any #^0.10.0
+  build_runner: ">=0.6.0 <2.0.0"
   coverage: ">=0.7.2 <0.12.4"
   dart_dev: ">=1.9.6 <3.0.0"
   dependency_validator: ^1.2.2
-  build_test: any
-  build_web_compilers: any
+  build_test: ">=0.9.4 <=0.11.0"
+  build_web_compilers: ">=0.2.0 <2.0.0"
 
 transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
-
-dependency_overrides:
-  over_react:
-    path: /Users/corwinsheahan/.publink/over_react
-  dart_dev:
-    path: /Users/corwinsheahan/.publink/dart_dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,27 +14,19 @@ dependencies:
   test: any #^0.12.32+1
 dev_dependencies:
   build_runner: any #^0.10.0
-  coverage: ">=0.10.0 <0.12.4"
-  dart_dev: ">=1.7.7 <3.0.0"
-  dependency_validator: ^1.1.0
+  coverage: ">=0.7.2 <0.12.4"
+  dart_dev: ">=1.9.6 <3.0.0"
+  dependency_validator: ^1.2.2
   build_test: any
   build_web_compilers: any
-  transformer_utils: any
-#transformers:
-#  - over_react
-#  - test/pub_serve:
-#      $include: test/**_test{.*,}.dart
+
+transformers:
+  - over_react
+  - test/pub_serve:
+      $include: test/**_test{.*,}.dart
 
 dependency_overrides:
   over_react:
-    git:
-      url: git@github.com:Workiva/over_react.git
-      ref: ca45e3783180d6a928ad7d38145b4e66a388b2f7 # from builder_generate_public_class
-  transformer_utils:
-    git:
-      url: git@github.com:workiva/dart_transformer_utils.git
-      ref: cc2200ab8e6fb408899b64e53b4aedb0ac69ca5f # from dart2_compat
-  built_redux:
-    git:
-      url: git@github.com:corwinsheahan-wf/built_redux.git
-      ref: 9c9580242e8af6b905ef26c452600dca2195a98b # from bump_build_runner
+    path: /Users/corwinsheahan/.publink/over_react
+  dart_dev:
+    path: /Users/corwinsheahan/.publink/dart_dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/Workiva/over_react_test/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.24.2 <2.0.0"
+  sdk: ">=1.24.2 <3.0.0"
 dependencies:
   js: ^0.6.1
   matcher: ^0.12.1+4
   over_react: ^1.25.0
   react: ">=3.7.0 <5.0.0"
-  test: ^0.12.32+1
+  test: any #^0.12.32+1
 dev_dependencies:
   coverage: ">=0.7.2 <0.11.0"
   dart_dev: ^1.9.6

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -19,10 +19,12 @@ import 'package:test/test.dart';
 /// Main entry point for `validation_util.dart` testing.
 main() {
   group('ValidationUtil:', () {
+    // ignore: unnecessary_lambdas
     setUp(() {
       startRecordingValidationWarnings();
     });
 
+    // ignore: unnecessary_lambdas
     tearDown(() {
       stopRecordingValidationWarnings();
     });


### PR DESCRIPTION
## Ultimate problem:
Need dart 2 compatibility

## How it was fixed:
* Dependency updates
* Typing updates
* Comment out the function `getComponentPropKeys`. This method uses mirrors, which are not compatible with web development on Dart 2. [AF-3700](https://jira.atl.workiva.net/browse/AF-3700) will re-add this functionality back in w/out using mirrors once we're fully transitioned to Dart 2

## Testing suggestions:
* CI Passes (currently only running Dart 1)
* Pull this branch locally and publink the builder_generate_public_class branch of over_react to allow pub get to resolve on Dart 2. Then, verify that all tests pass on Dart 2.

## Potential areas of regression:


---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @joelleibow-wf @evanweible-wf @sebastianmalysa-wf @robbecker-wf 
