### PR TITLE
AF-3857: run latest codemod

### DIFF
--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -22,7 +22,9 @@ part 'wrapper_component.over_react.g.dart';
 /// for compatability with `getByTestId()`.
 @Factory()
 // ignore: undefined_identifier
-UiFactory<UiProps> Wrapper = $Wrapper;
+UiFactory<UiProps> Wrapper =
+    // ignore: undefined_identifier
+    _$Wrapper;
 
 @Props()
 class _$WrapperProps extends UiProps {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   js: ^0.6.1
   matcher: ^0.12.1+4
-  over_react: ^1.30.0
+  over_react: ^1.30.2
   react: ">=3.7.0 <5.0.0"
   test: ">=0.12.32+1 <2.0.0"
 dev_dependencies:

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -212,7 +212,9 @@ main() {
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<SampleProps> Sample = $Sample;
+UiFactory<SampleProps> Sample =
+    // ignore: undefined_identifier
+    _$Sample;
 
 @Props()
 class _$SampleProps extends UiProps {

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1176,7 +1176,9 @@ main() {
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<TestProps> Test = $Test;
+UiFactory<TestProps> Test =
+    // ignore: undefined_identifier
+    _$Test;
 
 @Props()
 class _$TestProps extends UiProps {}

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -19,7 +19,9 @@ part 'nested_component.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<NestedProps> Nested = $Nested;
+UiFactory<NestedProps> Nested =
+    // ignore: undefined_identifier
+    _$Nested;
 
 @Props()
 class _$NestedProps extends UiProps {}

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -21,7 +21,9 @@ part 'test_common_component.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<TestCommonProps> TestCommon = $TestCommon;
+UiFactory<TestCommonProps> TestCommon =
+    // ignore: undefined_identifier
+    _$TestCommon;
 
 @Props()
 class _$TestCommonProps extends UiProps with
@@ -54,7 +56,7 @@ abstract class PropsThatShouldBeForwarded {
   // To ensure the codemod regression checking works properly, please keep this
   // field at the top of the class!
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForPropsThatShouldBeForwarded;
+  static const PropsMeta meta = _$metaForPropsThatShouldBeForwarded;
 
   Map get props;
 
@@ -66,7 +68,7 @@ abstract class PropsThatShouldNotBeForwarded {
   // To ensure the codemod regression checking works properly, please keep this
   // field at the top of the class!
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForPropsThatShouldNotBeForwarded;
+  static const PropsMeta meta = _$metaForPropsThatShouldNotBeForwarded;
 
   Map get props;
 

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -22,7 +22,9 @@ part 'test_common_component_nested.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<TestCommonNestedProps> TestCommonNested = $TestCommonNested;
+UiFactory<TestCommonNestedProps> TestCommonNested =
+    // ignore: undefined_identifier
+    _$TestCommonNested;
 
 @Props()
 class _$TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -19,7 +19,9 @@ part 'test_common_component_nested2.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<TestCommonNested2Props> TestCommonNested2 = $TestCommonNested2;
+UiFactory<TestCommonNested2Props> TestCommonNested2 =
+    // ignore: undefined_identifier
+    _$TestCommonNested2;
 
 @Props()
 class _$TestCommonNested2Props extends UiProps {}

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -19,7 +19,9 @@ part 'test_common_component_required_props.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
-UiFactory<TestCommonRequiredProps> TestCommonRequired = $TestCommonRequired;
+UiFactory<TestCommonRequiredProps> TestCommonRequired =
+    // ignore: undefined_identifier
+    _$TestCommonRequired;
 
 @Props()
 class _$TestCommonRequiredProps extends UiProps {


### PR DESCRIPTION
## Ultimate problem:
Dart 1-2 transition boilerplate updated to make the initializers for factories and meta constants private. This repo needed to be updated.

## How it was fixed:
Re-run codemod script

## Testing suggestions:
CI Passes

## Potential areas of regression:
None

---
> __FYA:__ @evanweible-wf @sebastianmalysa-wf @smaifullerton-wk @georgelesica-wf 
