### PR TITLE
AF-3891: make metaFor initializers private

### DIFF
--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -39,5 +39,5 @@ class WrapperComponent extends UiComponent<WrapperProps> {
 // ignore: mixin_of_non_class, undefined_class
 class WrapperProps extends _$WrapperProps with _$WrapperPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForWrapperProps;
+  static const PropsMeta meta = _$metaForWrapperProps;
 }

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -244,12 +244,12 @@ class SampleComponent extends UiStatefulComponent<SampleProps, SampleState> {
 // ignore: mixin_of_non_class, undefined_class
 class SampleProps extends _$SampleProps with _$SamplePropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForSampleProps;
+  static const PropsMeta meta = _$metaForSampleProps;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
 // ignore: mixin_of_non_class, undefined_class
 class SampleState extends _$SampleState with _$SampleStateAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = $metaForSampleState;
+  static const StateMeta meta = _$metaForSampleState;
 }

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1193,5 +1193,5 @@ class TestComponent extends UiComponent<TestProps> {
 // ignore: mixin_of_non_class, undefined_class
 class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForTestProps;
+  static const PropsMeta meta = _$metaForTestProps;
 }

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -43,5 +43,5 @@ class NestedComponent extends UiComponent<NestedProps> {
 // ignore: mixin_of_non_class, undefined_class
 class NestedProps extends _$NestedProps with _$NestedPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForNestedProps;
+  static const PropsMeta meta = _$metaForNestedProps;
 }

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -79,5 +79,5 @@ abstract class PropsThatShouldNotBeForwarded {
 // ignore: mixin_of_non_class, undefined_class
 class TestCommonProps extends _$TestCommonProps with _$TestCommonPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForTestCommonProps;
+  static const PropsMeta meta = _$metaForTestCommonProps;
 }

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -43,5 +43,5 @@ class TestCommonNestedComponent extends UiComponent<TestCommonNestedProps> {
 // ignore: mixin_of_non_class, undefined_class
 class TestCommonNestedProps extends _$TestCommonNestedProps with _$TestCommonNestedPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForTestCommonNestedProps;
+  static const PropsMeta meta = _$metaForTestCommonNestedProps;
 }

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -40,5 +40,5 @@ class TestCommonNested2Component extends UiComponent<TestCommonNested2Props> {
 // ignore: mixin_of_non_class, undefined_class
 class TestCommonNested2Props extends _$TestCommonNested2Props with _$TestCommonNested2PropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForTestCommonNested2Props;
+  static const PropsMeta meta = _$metaForTestCommonNested2Props;
 }

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -48,5 +48,5 @@ class TestCommonRequiredComponent extends UiComponent<TestCommonRequiredProps> {
 // ignore: mixin_of_non_class, undefined_class
 class TestCommonRequiredProps extends _$TestCommonRequiredProps with _$TestCommonRequiredPropsAccessorsMixin {
   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = $metaForTestCommonRequiredProps;
+  static const PropsMeta meta = _$metaForTestCommonRequiredProps;
 }


### PR DESCRIPTION
## Ultimate problem:
Need to make `$metaFor` initializers private

## How it was fixed:
Make them private

## Testing suggestions:
CI Passes

## Potential areas of regression:
None

---
> __FYA:__ @evanweible-wf @sebastianmalysa-wf @georgelesica-wf 
