### PR TITLE
AF-3890 Release over_react_test 2.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.1.0
+version: 2.2.0
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [AF-3891: make metaFor initializers private](https://github.com/Workiva/over_react_test/pull/56)


Requested by: @corwin.sheahan

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/2.1.0...Workiva:release_over_react_test_2.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/2.1.0...2.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)