### PR TITLE
CP-4147: Widen over_react range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 dist: precise
 dart:
-  - "1.24.2"
+  - "1.24.3"
 env:
   - DARTIUM_EXPIRATION_TIME="1577836800"
 with_content_shell: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   js: ^0.6.1
   matcher: ^0.12.1+4
-  over_react: ^1.30.2
+  over_react: ">=1.31.0 <3.0.0"
   react: ">=3.7.0 <5.0.0"
   test: ">=0.12.32+1 <2.0.0"
 dev_dependencies:


### PR DESCRIPTION
## Ultimate problem:
over_react 2.x release is imminent, need to widen range to include 2.x

## How it was fixed:
Widen range

## Testing suggestions:
* CI Passes

## Potential areas of regression:
N/A

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @maxwellpeterson-wf @evanweible-wf @sebastianmalysa-wf @smaifullerton-wk @georgelesica-wf 