### PR TITLE
CPLAT-4301 : Make compatible with react.dart 5.0.0-wip

### DIFF
--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -61,7 +61,7 @@ class TestJacket<T extends react.Component> {
   final Element mountNode;
   final bool attachedToDocument;
   final bool autoTearDown;
-  bool _isMounted;
+  bool _isMounted = false;
 
   TestJacket._(over_react.ReactElement reactElement, {Element mountNode, this.attachedToDocument: false, this.autoTearDown: true})
       : this.mountNode = mountNode ?? (new DivElement()
@@ -114,9 +114,7 @@ class TestJacket<T extends react.Component> {
   }
 
   /// Returns if the jacket component is mounted or not.
-  bool isMounted() {
-    return _isMounted;
-  }
+  bool get isMounted => _isMounted;
 
   /// Update the Dart component's state to the provided [newState] value and force a re-render.
   ///

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -66,15 +66,21 @@ class TestJacket<T extends react.Component> {
   TestJacket._(over_react.ReactElement reactElement, {Element mountNode, this.attachedToDocument: false, this.autoTearDown: true})
       : this.mountNode = mountNode ?? (new DivElement()
           ..style.height = '800px'
-          ..style.width= '800px') {
+          ..style.width = '800px') {
     _render(reactElement);
   }
 
   void _render(over_react.ReactElement reactElement) {
     _isMounted = true;
     _renderedInstance = attachedToDocument
-        ? react_util.renderAttachedToDocument(reactElement, container: mountNode, autoTearDown: autoTearDown)
-        : react_util.render(reactElement, container: mountNode, autoTearDown: autoTearDown);
+        ? react_util.renderAttachedToDocument(reactElement,
+            container: mountNode,
+            autoTearDown: autoTearDown,
+            autoTearDownCallback: unmount)
+        : react_util.render(reactElement,
+            container: mountNode,
+            autoTearDown: autoTearDown,
+            autoTearDownCallback: unmount);
   }
 
   /// Rerenders the [reactElement] into the same [mountNode].

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -61,6 +61,7 @@ class TestJacket<T extends react.Component> {
   final Element mountNode;
   final bool attachedToDocument;
   final bool autoTearDown;
+  bool _isMounted;
 
   TestJacket._(over_react.ReactElement reactElement, {Element mountNode, this.attachedToDocument: false, this.autoTearDown: true})
       : this.mountNode = mountNode ?? (new DivElement()
@@ -70,6 +71,7 @@ class TestJacket<T extends react.Component> {
   }
 
   void _render(over_react.ReactElement reactElement) {
+    _isMounted = true;
     _renderedInstance = attachedToDocument
         ? react_util.renderAttachedToDocument(reactElement, container: mountNode, autoTearDown: autoTearDown)
         : react_util.render(reactElement, container: mountNode, autoTearDown: autoTearDown);
@@ -105,6 +107,11 @@ class TestJacket<T extends react.Component> {
     return over_react.getDartComponent(_renderedInstance) as T;
   }
 
+  /// Returns if the jacket component is mounted or not.
+  bool isMounted() {
+    return _isMounted;
+  }
+
   /// Update the Dart component's state to the provided [newState] value and force a re-render.
   ///
   /// Optionally accepts a callback that gets called after the component updates.
@@ -118,6 +125,7 @@ class TestJacket<T extends react.Component> {
 
   /// Unmounts the React component instance and cleans up any attached DOM nodes.
   void unmount() {
+    _isMounted = false;
     react_util.unmount(_renderedInstance);
     mountNode?.remove();
     react_util.tearDownAttachedNodes();

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -96,9 +96,11 @@ void unmount(dynamic instanceOrContainerNode) {
       react_test_utils.isCompositeComponent(instanceOrContainerNode) ||
       react_test_utils.isDOMComponent(instanceOrContainerNode)
   ) {
-    if (!instanceOrContainerNode.isMounted()) return;
-
-    containerNode = findDomNode(instanceOrContainerNode)?.parent;
+    try {
+      containerNode = findDomNode(instanceOrContainerNode)?.parent;
+    } catch(e) {
+      return;
+    }
   } else {
     throw new ArgumentError(
         '`instanceOrNode` must be null, a ReactComponent instance, or an Element. Was: $instanceOrContainerNode.'

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -49,7 +49,8 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// Renders a React component or builder into a detached node and returns the component instance.
 ///
 /// By default the rendered instance will be unmounted after the current test, to prevent this behavior set
-/// [autoTearDown] to false.
+/// [autoTearDown] to false. If [autoTearDown] is set to true once it will, if provided, call [autoTearDownCallback]
+/// once the component has been unmounted.
 /* [1] */ render(dynamic component,
     {bool autoTearDown = true,
     Element container,
@@ -78,9 +79,12 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// [autoTearDown] to false.
 ///
 /// See: <https://facebook.github.io/react/docs/test-utils.html#shallow-rendering>.
-ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true}) {
+ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Callback autoTearDownCallback}) {
   var renderer = react_test_utils.createRenderer();
-  if (autoTearDown) addTearDown(() => renderer.unmount());
+  if (autoTearDown) addTearDown(() {
+    renderer.unmount();
+    if (autoTearDownCallback != null) autoTearDownCallback();
+  });
   renderer.render(instance);
   return renderer.getRenderOutput();
 }
@@ -121,14 +125,14 @@ void unmount(dynamic instanceOrContainerNode) {
 ///
 /// By default the rendered instance will be unmounted after the current test, to prevent this behavior set
 /// [autoTearDown] to false.
-Element renderAndGetDom(dynamic component, {bool autoTearDown: true}) {
-  return findDomNode(render(component, autoTearDown: autoTearDown));
+Element renderAndGetDom(dynamic component, {bool autoTearDown: true, Callback autoTearDownCallback}) {
+  return findDomNode(render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback));
 }
 
 /// Renders a React component or builder into a detached node and returns the associtated Dart component.
 react.Component renderAndGetComponent(dynamic component,
-        {bool autoTearDown: true}) =>
-    getDartComponent(render(component, autoTearDown: autoTearDown));
+        {bool autoTearDown: true, Callback autoTearDownCallback}) =>
+    getDartComponent(render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback));
 
 /// List of elements attached to the DOM and used as mount points in previous calls to [renderAttachedToDocument].
 List<Element> _attachedReactContainers = [];

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -50,7 +50,10 @@ export 'package:over_react/src/util/react_wrappers.dart';
 ///
 /// By default the rendered instance will be unmounted after the current test, to prevent this behavior set
 /// [autoTearDown] to false.
-/* [1] */ render(dynamic component, {bool autoTearDown = true, Element container}) {
+/* [1] */ render(dynamic component,
+    {bool autoTearDown = true,
+    Element container,
+    Callback autoTearDownCallback}) {
   var renderedInstance;
   component = component is component_base.UiProps ? component.build() : component;
 
@@ -60,7 +63,11 @@ export 'package:over_react/src/util/react_wrappers.dart';
     renderedInstance = react_dom.render(component, container);
   }
 
-  if (autoTearDown) addTearDown(() => unmount(renderedInstance));
+  if (autoTearDown)
+    addTearDown(() {
+      unmount(renderedInstance);
+      if (autoTearDownCallback != null) autoTearDownCallback();
+    });
 
   return renderedInstance;
 }
@@ -98,7 +105,7 @@ void unmount(dynamic instanceOrContainerNode) {
   ) {
     try {
       containerNode = findDomNode(instanceOrContainerNode)?.parent;
-    } catch(e) {
+    } catch (e) {
       return;
     }
   } else {
@@ -119,7 +126,9 @@ Element renderAndGetDom(dynamic component, {bool autoTearDown: true}) {
 }
 
 /// Renders a React component or builder into a detached node and returns the associtated Dart component.
-react.Component renderAndGetComponent(dynamic component, {bool autoTearDown: true}) => getDartComponent(render(component, autoTearDown: autoTearDown));
+react.Component renderAndGetComponent(dynamic component,
+        {bool autoTearDown: true}) =>
+    getDartComponent(render(component, autoTearDown: autoTearDown));
 
 /// List of elements attached to the DOM and used as mount points in previous calls to [renderAttachedToDocument].
 List<Element> _attachedReactContainers = [];
@@ -127,7 +136,10 @@ List<Element> _attachedReactContainers = [];
 /// Renders the component into a node attached to document.body as opposed to a detached node.
 ///
 /// Returns the rendered component.
-/* [1] */ renderAttachedToDocument(dynamic component, {bool autoTearDown = true, Element container}) {
+/* [1] */ renderAttachedToDocument(dynamic component,
+    {bool autoTearDown = true,
+    Element container,
+    Callback autoTearDownCallback}) {
   container ??= new DivElement()
     // Set arbitrary height and width for container to ensure nothing is cut off.
     ..style.setProperty('width', '800px')
@@ -139,6 +151,7 @@ List<Element> _attachedReactContainers = [];
     addTearDown(() {
       react_dom.unmountComponentAtNode(container);
       container.remove();
+      if (autoTearDownCallback != null) autoTearDownCallback();
     });
   } else {
     _attachedReactContainers.add(container);
@@ -288,7 +301,7 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-List/* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defaultTestIdKey}) {
+List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defaultTestIdKey}) {
   if (root is react.Component) root = root.jsThis;
 
   if (isValidElement(root)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,9 +24,3 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
-
-
-dependency_overrides:
-  over_react:
-    path: /Users/kealjones/.publink/over_react
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,3 +24,9 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
+
+
+dependency_overrides:
+  over_react:
+    path: /Users/kealjones/.publink/over_react
+

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -34,7 +34,7 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isFalse);
+          expect(jacket.isMounted(), isFalse);
 
           jacket = null;
         });
@@ -44,14 +44,14 @@ main() {
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
           expect(document.body.children[0], mountNode);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isNotNull);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isNotNull);
           expect(document.body.children[0].children[0], jacket.getNode());
         });
       });
@@ -65,12 +65,12 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isNotEmpty);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
 
           jacket.unmount();
 
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isFalse);
+          expect(jacket.isMounted(), isFalse);
 
           jacket = null;
         });
@@ -80,14 +80,14 @@ main() {
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode, autoTearDown: false);
 
           expect(document.body.children[0], mountNode);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
           expect(document.body.children[0].children[0], jacket.getNode());
         });
       });
@@ -103,7 +103,7 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isFalse);
+          expect(jacket.isMounted(), isFalse);
 
           jacket = null;
         });
@@ -113,14 +113,14 @@ main() {
           jacket = mount(Sample()(), mountNode: mountNode);
 
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()());
 
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
         });
       });
 
@@ -133,12 +133,12 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
 
           jacket.unmount();
 
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isFalse);
+          expect(jacket.isMounted(), isFalse);
 
           jacket = null;
         });
@@ -148,7 +148,7 @@ main() {
           jacket = mount(Sample()(), mountNode: mountNode, autoTearDown: false);
 
           expect(document.body.children.isEmpty, isTrue);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
@@ -156,7 +156,7 @@ main() {
           jacket = mount(Sample()(), autoTearDown: false);
 
           expect(document.body.children, isEmpty);
-          expect(jacket.getInstance().isMounted(), isTrue);
+          expect(jacket.isMounted(), isTrue);
         });
       });
     });
@@ -201,11 +201,11 @@ main() {
     });
 
     test('unmount', () {
-      expect(jacket.getInstance().isMounted(), isTrue);
+      expect(jacket.isMounted(), isTrue);
 
       jacket.unmount();
 
-      expect(jacket.getInstance().isMounted(), isFalse);
+      expect(jacket.isMounted(), isFalse);
     });
   });
 }

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -44,14 +44,14 @@ main() {
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
           expect(document.body.children[0], mountNode);
-          expect(jacket.isMounted(), isNotNull);
+          expect(jacket.isMounted(), isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket.isMounted(), isNotNull);
+          expect(jacket.isMounted(), isTrue);
           expect(document.body.children[0].children[0], jacket.getNode());
         });
       });
@@ -77,7 +77,11 @@ main() {
 
         test('with the given container', () {
           var mountNode = new DivElement();
-          jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode, autoTearDown: false);
+          jacket = mount(Sample()(),
+              attachedToDocument: true,
+              mountNode: mountNode,
+              autoTearDown: false
+          );
 
           expect(document.body.children[0], mountNode);
           expect(jacket.isMounted(), isTrue);
@@ -85,7 +89,8 @@ main() {
         });
 
         test('without the given container', () {
-          jacket = mount(Sample()(), attachedToDocument: true, autoTearDown: false);
+          jacket =
+              mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
           expect(jacket.isMounted(), isTrue);
           expect(document.body.children[0].children[0], jacket.getNode());

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -34,7 +34,7 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isFalse);
+          expect(jacket.isMounted, isFalse);
 
           jacket = null;
         });
@@ -44,14 +44,14 @@ main() {
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
           expect(document.body.children[0], mountNode);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(document.body.children[0].children[0], jacket.getNode());
         });
       });
@@ -65,12 +65,12 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isNotEmpty);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
 
           jacket.unmount();
 
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isFalse);
+          expect(jacket.isMounted, isFalse);
 
           jacket = null;
         });
@@ -84,7 +84,7 @@ main() {
           );
 
           expect(document.body.children[0], mountNode);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
@@ -92,7 +92,7 @@ main() {
           jacket =
               mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(document.body.children[0].children[0], jacket.getNode());
         });
       });
@@ -108,7 +108,7 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isFalse);
+          expect(jacket.isMounted, isFalse);
 
           jacket = null;
         });
@@ -118,14 +118,14 @@ main() {
           jacket = mount(Sample()(), mountNode: mountNode);
 
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()());
 
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
         });
       });
 
@@ -138,12 +138,12 @@ main() {
 
         tearDown(() {
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
 
           jacket.unmount();
 
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isFalse);
+          expect(jacket.isMounted, isFalse);
 
           jacket = null;
         });
@@ -153,7 +153,7 @@ main() {
           jacket = mount(Sample()(), mountNode: mountNode, autoTearDown: false);
 
           expect(document.body.children.isEmpty, isTrue);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
           expect(mountNode.children[0], jacket.getNode());
         });
 
@@ -161,7 +161,7 @@ main() {
           jacket = mount(Sample()(), autoTearDown: false);
 
           expect(document.body.children, isEmpty);
-          expect(jacket.isMounted(), isTrue);
+          expect(jacket.isMounted, isTrue);
         });
       });
     });
@@ -206,11 +206,11 @@ main() {
     });
 
     test('unmount', () {
-      expect(jacket.isMounted(), isTrue);
+      expect(jacket.isMounted, isTrue);
 
       jacket.unmount();
 
-      expect(jacket.isMounted(), isFalse);
+      expect(jacket.isMounted, isFalse);
     });
   });
 }

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -38,7 +38,10 @@ main() {
       var renderedInstance;
 
       tearDown(() {
-        expect(findDomNode(renderedInstance), throwsArgumentError, reason: 'The React instance should have been unmounted.');
+        expect(() => findDomNode(renderedInstance),
+            throwsA(hasToStringValue(contains('findDOMNode was called on an unmounted component'))),
+            reason: 'The React instance should have been unmounted.'
+        );
 
         expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
       });
@@ -75,7 +78,10 @@ main() {
 
       tearDownAttachedNodes();
 
-      expect(findDomNode(renderedInstance), throwsArgumentError, reason: 'The React instance should have been unmounted.');
+      expect(() => findDomNode(renderedInstance),
+      throwsA(hasToStringValue(contains('findDOMNode was called on an unmounted component'))),
+          reason: 'The React instance should have been unmounted.'
+      );
 
       expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
     });

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -38,7 +38,7 @@ main() {
       var renderedInstance;
 
       tearDown(() {
-        expect(renderedInstance.isMounted(), isFalse, reason: 'The React instance should have been unmounted.');
+        expect(findDomNode(renderedInstance), throwsArgumentError, reason: 'The React instance should have been unmounted.');
 
         expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
       });
@@ -75,7 +75,7 @@ main() {
 
       tearDownAttachedNodes();
 
-      expect(renderedInstance.isMounted(), isFalse, reason: 'The React instance should have been unmounted.');
+      expect(findDomNode(renderedInstance), throwsArgumentError, reason: 'The React instance should have been unmounted.');
 
       expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
     });
@@ -1123,10 +1123,7 @@ main() {
         test('by its rendered instance', () {
           var mountNode = new DivElement();
           var instance = react_dom.render(Wrapper()(), mountNode);
-          expect(instance.isMounted(), isTrue);
-
-          unmount(instance);
-          expect(instance.isMounted(), isFalse);
+          expect(react_dom.unmountComponentAtNode(mountNode), isTrue);
         });
 
         test('by its mount node', () {

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -39,7 +39,10 @@ main() {
 
       tearDown(() {
         expect(() => findDomNode(renderedInstance),
-            throwsA(hasToStringValue(contains('findDOMNode was called on an unmounted component'))),
+            throwsA(anyOf(
+                hasToStringValue(contains('unmounted component')),
+                hasToStringValue(contains('Invariant Violation'))
+            )),
             reason: 'The React instance should have been unmounted.'
         );
 
@@ -79,7 +82,10 @@ main() {
       tearDownAttachedNodes();
 
       expect(() => findDomNode(renderedInstance),
-      throwsA(hasToStringValue(contains('findDOMNode was called on an unmounted component'))),
+          throwsA(anyOf(
+              hasToStringValue(contains('unmounted component')),
+              hasToStringValue(contains('Invariant Violation'))
+          )),
           reason: 'The React instance should have been unmounted.'
       );
 


### PR DESCRIPTION
## Ultimate problem:
We need support for react-dart 5.0.0 (React 16) which no longer supports `isMounted`. 

## How it was fixed:
- Add an `isMounted` method to TestJacket that is based upon a private variable that determines if the mount/unmount methods have been called.
- Add an `autoTearDownCallback` named argument to `render` and `renderAttachedToDocument` that allows the TestJacket to keep track of the `isMounted` status.  

## Testing suggestions:
- [x] CI Passes
- [x] All tests should pass locally using dart2 when publinked with https://github.com/Workiva/over_react/pull/255 and https://github.com/cleandart/react-dart/tree/5.0.0-wip

## Potential areas of regression:
probably.

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf
