### PR TITLE
Work around a bug in DDC where SvgElement className isn't String

### DIFF
--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:html';
+import 'dart:svg';
 
 import 'package:over_react/over_react.dart';
 import 'package:matcher/matcher.dart';
@@ -53,8 +54,20 @@ class ClassNameMatcher extends Matcher {
   }
 
   @override
-  bool matches(covariant String className, Map matchState) {
-    Iterable actualClasses = getClassIterable(className);
+  bool matches(className, Map matchState) {
+    // There's a bug in DDC where, though the docs say `className` should
+    // return `String`, it will return `AnimatedString` for `SvgElement`s. See
+    // https://github.com/dart-lang/sdk/issues/36200.
+    String castClassName;
+    if (className is String) {
+      castClassName = className;
+    } else if (className is AnimatedString) {
+      castClassName = className.baseVal;
+    } else {
+      throw new ArgumentError.value(className, 'Must be a string type');
+    }
+
+    Iterable actualClasses = getClassIterable(castClassName);
     Set missingClasses = expectedClasses.difference(actualClasses.toSet());
     Set unwantedClasses = unexpectedClasses.intersection(actualClasses.toSet());
 

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:html';
+import 'dart:svg';
 
 import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
@@ -86,6 +87,13 @@ main() {
 
         test('the element has the exact classes (specified as an Iterable)', () {
           testElement.className = 'class1 class2';
+          shouldPass(testElement, hasExactClasses(['class1', 'class2']));
+        });
+
+        test('the element has the exact classes and is an SvgElement', () {
+          // Test workaround for https://github.com/dart-lang/sdk/issues/36200.
+          // This may be removed when the workaround is removed.
+          testElement = new SvgElement.svg('<svg class="class1 class2"/>');
           shouldPass(testElement, hasExactClasses(['class1', 'class2']));
         });
       });


### PR DESCRIPTION
## Ultimate problem:
As described at https://github.com/dart-lang/sdk/issues/36200, `SvgElement`'s `className` property returns `AnimatedString` in DDC. This makes classname matchers unusable with `SvgElement` due to runtime type errors.

## How it was fixed:
Work around the issue by explicitly taking `AnimatedString` and getting a usable `String` value out of it.

## Testing suggestions:
Test added. CI passes.

## Potential areas of regression:
Use of classname matchers.

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
