### PR TITLE
[WIP] Run Dart 1 tests in Workiva Build only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 
 dart:
-  - "1.24.3"
   - stable
 
 # Re-use downloaded pub packages everywhere.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,18 +5,18 @@ homepage: https://github.com/Workiva/over_react_test/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.24.2 <3.0.0"
+  sdk: ">=1.24.3 <3.0.0"
 dependencies:
-  js: ^0.6.1
+  js: ^0.6.1+1
   matcher: ^0.12.1+4
-  over_react: ">=1.31.0 <3.0.0"
-  react: ">=3.7.0 <5.0.0"
-  test: ">=0.12.32+1 <2.0.0"
+  over_react: ">=1.33.1 <3.0.0"
+  react: ^4.6.2
+  test: ">=0.12.34 <2.0.0"
 dev_dependencies:
-  build_runner: ">=0.6.0 <2.0.0"
-  coverage: ">=0.7.2 <0.12.4"
-  dart_dev: ">=1.9.6 <3.0.0"
-  dependency_validator: ^1.2.2
+  build_runner: ">=0.6.0+1 <2.0.0"
+  coverage: ">=0.10.0 <0.12.4"
+  dart_dev: ^2.0.4
+  dependency_validator: ^1.2.4
   build_test: ">=0.9.4 <=0.11.0"
   build_web_compilers: ">=0.2.0 <2.0.0"
 


### PR DESCRIPTION
## Motivation
At the moment, we can’t get the Dart 1 SDK version solver to complete when running `pub get` on Travis

## Changes
Temporarily run Dart 1 tests in Workiva Build (using the Dart 2 pub get workaround) until we switch over to Dart 2 only.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Travis and Workiva Build CI Passes
- [ ] Tests are run in Dart 1 on Workiva Build

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
