### PR TITLE
CPLAT-5648 Accommodate findAllInRenderedTree being passed text nodes in React 16

### DIFF
--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -507,18 +507,14 @@ List findDescendantsWithProp(/* [1] */ root, dynamic propKey) {
       return false;
     }
 
-    if (react_test_utils.isCompositeComponent(descendant)) {
-      if (isDartComponent(descendant)) {
-        // TODO why not just `getProps` for this case?
-        return getDartComponent(descendant).props.containsKey(propKey);
-      } else {
-        return getProps(descendant).containsKey(propKey);
-      }
-    } else if (react_test_utils.isDOMComponent(descendant)) {
-      return findDomNode(descendant).attributes.containsKey(propKey);
+    Map props;
+    if (react_test_utils.isDOMComponent(descendant)) {
+      props = findDomNode(descendant).attributes;
+    } else if (react_test_utils.isCompositeComponent(descendant)) {
+      props = getProps(descendant);
     }
 
-    return false;
+    return props != null && props.containsKey(propKey);
   }));
 
   return descendantsWithProp;

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -313,11 +313,13 @@ List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key: defau
   }
 
   return react_test_utils.findAllInRenderedTree(root, allowInterop((descendant) {
-    var props = react_test_utils.isDOMComponent(descendant)
-        ? findDomNode(descendant).attributes
-        : getProps(descendant);
-
-    return _hasTestId(props, key, value);
+    Map props;
+    if (react_test_utils.isDOMComponent(descendant)) {
+      props = findDomNode(descendant).attributes;
+    } else if (react_test_utils.isCompositeComponent(descendant)) {
+      props = getProps(descendant);
+    }
+    return props != null && _hasTestId(props, key, value);
   }));
 }
 
@@ -505,16 +507,18 @@ List findDescendantsWithProp(/* [1] */ root, dynamic propKey) {
       return false;
     }
 
-    bool hasProp;
-    if (isDartComponent(descendant)) {
-      hasProp = getDartComponent(descendant).props.containsKey(propKey);
-    } else if (react_test_utils.isCompositeComponent(descendant)) {
-      hasProp = getProps(descendant).containsKey(propKey);
+    if (react_test_utils.isCompositeComponent(descendant)) {
+      if (isDartComponent(descendant)) {
+        // TODO why not just `getProps` for this case?
+        return getDartComponent(descendant).props.containsKey(propKey);
+      } else {
+        return getProps(descendant).containsKey(propKey);
+      }
     } else if (react_test_utils.isDOMComponent(descendant)) {
-      hasProp = findDomNode(descendant).attributes.containsKey(propKey);
+      return findDomNode(descendant).attributes.containsKey(propKey);
     }
 
-    return hasProp;
+    return false;
   }));
 
   return descendantsWithProp;

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -607,6 +607,15 @@ main() {
           var descendants = getAllByTestId(renderedInstance, null);
           expect(descendants, isEmpty);
         });
+
+        test('without throwing when text nodes are present in the tree', () {
+          var renderedInstance = render(Wrapper()(
+            Dom.div()(),
+            'I will become a text node',
+          ));
+
+          expect(() => getAllByTestId(renderedInstance, 'data-null'), returnsNormally);
+        });
       }
 
       group('(rendered component)', () {
@@ -1106,28 +1115,39 @@ main() {
       });
     });
 
-    test('findDescendantsWithProp returns the descendants with the specified propKey', () {
-      var renderedInstance = render(Wrapper()([
-        (Dom.div()..addProp('data-name', 'top-level DOM'))(),
-        (Test()..addProp('data-name', 'top-level Dart'))(),
-        testJsComponentFactory({'data-name': 'top-level JS composite'}),
+    group('findDescendantsWithProp', () {
+      test('returns the descendants with the specified propKey', () {
+        var renderedInstance = render(Wrapper()([
+          (Dom.div()..addProp('data-name', 'top-level DOM'))(),
+          (Test()..addProp('data-name', 'top-level Dart'))(),
+          testJsComponentFactory({'data-name': 'top-level JS composite'}),
 
-        Dom.div()([
-          (Dom.div()..addProp('data-name', 'nested DOM'))(),
-          (Test()..addProp('data-name', 'nested Dart'))(),
-          testJsComponentFactory({'data-name': 'nested JS composite'}),
-        ])
-      ]));
+          Dom.div()([
+            (Dom.div()..addProp('data-name', 'nested DOM'))(),
+            (Test()..addProp('data-name', 'nested Dart'))(),
+            testJsComponentFactory({'data-name': 'nested JS composite'}),
+          ])
+        ]));
 
-      var descendants = findDescendantsWithProp(renderedInstance, 'data-name');
-      expect(descendants, [
-        hasProp('data-name', 'top-level DOM'),
-        hasProp('data-name', 'top-level Dart'),
-        hasProp('data-name', 'top-level JS composite'),
-        hasProp('data-name', 'nested DOM'),
-        hasProp('data-name', 'nested Dart'),
-        hasProp('data-name', 'nested JS composite'),
-      ]);
+        var descendants = findDescendantsWithProp(renderedInstance, 'data-name');
+        expect(descendants, [
+          hasProp('data-name', 'top-level DOM'),
+          hasProp('data-name', 'top-level Dart'),
+          hasProp('data-name', 'top-level JS composite'),
+          hasProp('data-name', 'nested DOM'),
+          hasProp('data-name', 'nested Dart'),
+          hasProp('data-name', 'nested JS composite'),
+        ]);
+      });
+
+      test('does not throw when text nodes are present in the tree', () {
+        var renderedInstance = render(Wrapper()(
+          Dom.div()(),
+          'I will become a text node',
+        ));
+
+        expect(() => findDescendantsWithProp(renderedInstance, 'data-null'), returnsNormally);
+      });
     });
 
     group('unmount:', () {


### PR DESCRIPTION
## Motivation
In React 16, the callback provided `react_test_utils.findAllInRenderedtree` gets called with DOM text nodes, whereas previously it was only called with DOM elements and React components.

Some utilities in over_react_test did not account for that, and threw as a result.

## Changes
- Update conditionals in `getAllByTestId` and `findDescendantsWithProp` to not assume that the callback argument is only ever either a DOM element or React component.
- Add regression tests

#### Release Notes
Update `getAllByTestId`/`findDescendantsWithProp` implementations to work in React 16.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

Please review: @aaronlademann-wf @kealjones-wk @joebingham-wk @tainhenning-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Verify that tests pass in React 16 (need to pull in react 5.0.0-wip and over_react 3.0.0-wip)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
