### PR TITLE
CPLAT-7370 Add Awareness for Component2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ADD . /build/
 # Use pub from Dart 2 to initially resolve dependencies since it is much more efficient.
 COPY --from=dart2 /usr/lib/dart /usr/lib/dart2
 RUN echo "Running Dart 2 pub get.." && \
-	_PUB_TEST_SDK_VERSION=1.24.3 timeout 5m /usr/lib/dart2/bin/pub get --no-precompile
+	_PUB_TEST_SDK_VERSION=2.4.1 timeout 5m /usr/lib/dart2/bin/pub get --no-precompile
 RUN echo "Starting the script sections" && \
 		dart --version && \
 		pub get && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM google/dart:2.2 as dart2
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
 
 # Build Environment Vars
 ARG BUILD_ID
@@ -24,21 +23,9 @@ RUN chmod 600 /root/.ssh/id_rsa
 RUN echo "Setting up ssh-agent for git-based dependencies"
 RUN eval "$(ssh-agent -s)" && \
 	ssh-add /root/.ssh/id_rsa
-ENV DARTIUM_EXPIRATION_TIME=1577836800
 WORKDIR /build/
 ADD . /build/
-# Use pub from Dart 2 to initially resolve dependencies since it is much more efficient.
-COPY --from=dart2 /usr/lib/dart /usr/lib/dart2
-RUN echo "Running Dart 2 pub get.." && \
-	_PUB_TEST_SDK_VERSION=2.4.1 timeout 5m /usr/lib/dart2/bin/pub get --no-precompile
-RUN echo "Starting the script sections" && \
-		dart --version && \
-		pub get && \
-		pub run dart_dev analyze && \
-		pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers
-RUN echo "Running tests" && \
-        pub run dart_dev test && \
-		echo "Done running tests"
+RUN dart --version && pub get
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -465,8 +465,6 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
               reason: '$propKey is not set');
         }
 
-        context['console']['error'] = originalConsoleError;
-
         var propsToAdd = {propKey: null};
 
         mount((factory()

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -463,6 +463,9 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
           expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
           expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
               reason: '$propKey is not set');
+
+          consoleErrors = [];
+          PropTypes.resetWarningCache();
         }
 
         var propsToAdd = {propKey: null};

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -438,7 +438,9 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
         consoleErrors.add(message);
         originalConsoleError.apply([message], thisArg: self);
       });
-      final reactComponentFactory = factory().componentFactory as ReactDartComponentFactoryProxy; // ignore: avoid_as
+
+      final reactComponentFactory = factory().componentFactory as
+          ReactDartComponentFactoryProxy2; // ignore: avoid_as
 
       requiredProps.forEach((String propKey) {
         if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
@@ -450,17 +452,20 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
           expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
           expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
               reason: '$propKey is not set');
-        } else {
-          var propsToAdd = {propKey: null};
-
-          mount((factory()
-            ..addAll(propsToAdd)
-          )(childrenFactory()));
-
-          expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-          expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
-              reason: '$propKey is not set');
         }
+
+        context['console']['error'] = originalConsoleError;
+
+        var propsToAdd = {propKey: null};
+
+        mount((factory()
+          ..addAll(propsToAdd)
+        )(childrenFactory()));
+
+        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
+        expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
+            reason: '$propKey is not set');
+
 
         context['console']['error'] = originalConsoleError;
       });

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -81,7 +81,7 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   bool shouldTestClassNameOverrides: true,
   bool ignoreDomProps: true,
   bool shouldTestRequiredProps: true,
-  bool useComponent2Tests = false,
+  bool isComponent2 = false,
   dynamic childrenFactory()
 }) {
   childrenFactory ??= _defaultChildrenFactory;
@@ -108,7 +108,7 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
     testClassNameOverrides(factory, childrenFactory);
   }
   if (shouldTestRequiredProps) {
-    testRequiredProps(factory, childrenFactory, useComponent2Tests);
+    testRequiredProps(factory, childrenFactory, isComponent2);
   }
 }
 
@@ -385,7 +385,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
 ///
 /// __Note__: All required props must be provided by [factory].
 void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
-    useComponent2Tests) {
+    bool isComponent2) {
   var keyToErrorMessage = {};
   var nullableProps = <String>[];
   var requiredProps = <String>[];
@@ -408,69 +408,82 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
     });
   });
 
-  test('throws when the required prop is not set or is null', () {
-    if (!useComponent2Tests) {
-      requiredProps.forEach((String propKey) {
-        final reactComponentFactory = factory().componentFactory as ReactDartComponentFactoryProxy; // ignore: avoid_as
+  if (!isComponent2) {
+    test('throws when the required prop is not set or is null', () {
+        requiredProps.forEach((String propKey) {
+          final reactComponentFactory = factory()
+              .componentFactory as ReactDartComponentFactoryProxy; // ignore: avoid_as
 
-        // Props that are defined in the default props map will never not be set.
-        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
-          var badRenderer = () => render((factory()
-            ..remove(propKey)
-          )(childrenFactory()));
+          // Props that are defined in the default props map will never not be set.
+          if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+            var badRenderer = () =>
+                render((factory()
+                  ..remove(propKey)
+                )(childrenFactory()));
 
-          expect(badRenderer, throwsPropError_Required(propKey, keyToErrorMessage[propKey]), reason: '$propKey is not set');
-        }
+            expect(badRenderer,
+                throwsPropError_Required(propKey, keyToErrorMessage[propKey]),
+                reason: '$propKey is not set');
+          }
 
-        var propsToAdd = {propKey: null};
-        var badRenderer = () => render((factory()
-          ..addAll(propsToAdd)
-        )(childrenFactory()));
+          var propsToAdd = {propKey: null};
+          var badRenderer = () =>
+              render((factory()
+                ..addAll(propsToAdd)
+              )(childrenFactory()));
 
-        expect(badRenderer, throwsPropError_Required(propKey, keyToErrorMessage[propKey]), reason: '$propKey is set to null');
-      });
-    } else {
-      PropTypes.resetWarningCache();
+          expect(badRenderer,
+              throwsPropError_Required(propKey, keyToErrorMessage[propKey]),
+              reason: '$propKey is set to null');
+        });
+    });
+  } else {
+    test('logs the correct errors when the required prop is not set or is '
+        'null', () {
+        PropTypes.resetWarningCache();
 
-      List<String> consoleErrors = [];
-      JsFunction originalConsoleError = context['console']['error'];
-      context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
-        consoleErrors.add(message);
-        originalConsoleError.apply([message], thisArg: self);
-      });
+        List<String> consoleErrors = [];
+        JsFunction originalConsoleError = context['console']['error'];
+        context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
+          consoleErrors.add(message);
+          originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
+              thisArg: self);
+        });
 
-      final reactComponentFactory = factory().componentFactory as
-          ReactDartComponentFactoryProxy2; // ignore: avoid_as
+        final reactComponentFactory = factory().componentFactory as
+        ReactDartComponentFactoryProxy2; // ignore: avoid_as
 
-      requiredProps.forEach((String propKey) {
-        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+        requiredProps.forEach((String propKey) {
+          if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+
+            mount((factory()
+              ..remove(propKey)
+            )(childrenFactory()));
+
+            expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
+            expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
+                reason: '$propKey is not set');
+          }
+
+          context['console']['error'] = originalConsoleError;
+
+          var propsToAdd = {propKey: null};
 
           mount((factory()
-            ..remove(propKey)
+            ..addAll(propsToAdd)
           )(childrenFactory()));
 
           expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
           expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
               reason: '$propKey is not set');
-        }
 
-        context['console']['error'] = originalConsoleError;
+          consoleErrors = [];
+          PropTypes.resetWarningCache();
+        });
 
-        var propsToAdd = {propKey: null};
-
-        mount((factory()
-          ..addAll(propsToAdd)
-        )(childrenFactory()));
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
-            reason: '$propKey is not set');
-
-
-        context['console']['error'] = originalConsoleError;
+        addTearDown(() => context['console']['error'] = originalConsoleError);
       });
-    }
-  });
+  }
 
   test('nullable props', () {
     nullableProps.forEach((String propKey) {

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -434,7 +434,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
       List<String> consoleErrors = [];
       JsFunction originalConsoleError = context['console']['error'];
-      context['console']['error'] = new JsFunction.withThis((self, message) {
+      context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
         originalConsoleError.apply([message], thisArg: self);
       });

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -440,49 +440,49 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   } else {
     test('logs the correct errors when the required prop is not set or is '
         'null', () {
-        PropTypes.resetWarningCache();
+      PropTypes.resetWarningCache();
 
-        List<String> consoleErrors = [];
-        JsFunction originalConsoleError = context['console']['error'];
-        context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
-          consoleErrors.add(message);
-          originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
-              thisArg: self);
-        });
+      List<String> consoleErrors = [];
+      JsFunction originalConsoleError = context['console']['error'];
+      context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
+        consoleErrors.add(message);
+        originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
+            thisArg: self);
+      });
 
-        final reactComponentFactory = factory().componentFactory as
-        ReactDartComponentFactoryProxy2; // ignore: avoid_as
+      final reactComponentFactory = factory().componentFactory as
+      ReactDartComponentFactoryProxy2; // ignore: avoid_as
 
-        requiredProps.forEach((String propKey) {
-          if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
-
-            mount((factory()
-              ..remove(propKey)
-            )(childrenFactory()));
-
-            expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-            expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
-                reason: '$propKey is not set');
-          }
-
-          context['console']['error'] = originalConsoleError;
-
-          var propsToAdd = {propKey: null};
+      requiredProps.forEach((String propKey) {
+        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
 
           mount((factory()
-            ..addAll(propsToAdd)
+            ..remove(propKey)
           )(childrenFactory()));
 
           expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
           expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
               reason: '$propKey is not set');
+        }
 
-          consoleErrors = [];
-          PropTypes.resetWarningCache();
-        });
+        context['console']['error'] = originalConsoleError;
 
-        addTearDown(() => context['console']['error'] = originalConsoleError);
+        var propsToAdd = {propKey: null};
+
+        mount((factory()
+          ..addAll(propsToAdd)
+        )(childrenFactory()));
+
+        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
+        expect(consoleErrors, [contains(keyToErrorMessage[propKey])],
+            reason: '$propKey is not set');
+
+        consoleErrors = [];
+        PropTypes.resetWarningCache();
       });
+
+      addTearDown(() => context['console']['error'] = originalConsoleError);
+    });
   }
 
   test('nullable props', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,13 +24,3 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
-
-dependency_overrides:
-  react:
-    git:
-      url: git@github.com:cleandart/react-dart.git
-      ref: CPLAT-2275-regression-test-Component2
-  over_react:
-    git:
-      url: git@github.com:Workiva/over_react.git
-      ref: CPLAT-2275-regression-test-Component2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,8 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: CPLAT-2275-regression-test-Component2
+      ref: 5.1.0-wip
   over_react:
     git:
       url: https://github.com/Workiva/over_react.git
-      ref: CPLAT-2275-regression-test-Component2
+      ref: 3.1.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,3 +24,13 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
+
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:cleandart/react-dart.git
+      ref: CPLAT-2275-regression-test-Component2
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: CPLAT-2275-regression-test-Component2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,9 +28,9 @@ transformers:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:cleandart/react-dart.git
+      url: https://github.com/cleandart/react-dart.git
       ref: CPLAT-2275-regression-test-Component2
   over_react:
     git:
-      url: git@github.com:Workiva/over_react.git
+      url: https://github.com/Workiva/over_react.git
       ref: CPLAT-2275-regression-test-Component2

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -37,7 +37,8 @@ main() {
             shouldTestRequiredProps: true,
             shouldTestClassNameMerging: false,
             shouldTestClassNameOverrides: false,
-            shouldTestPropForwarding: false);
+            shouldTestPropForwarding: false,
+        );
       });
 
     group('when passed a UiComponent2', () {
@@ -47,7 +48,8 @@ main() {
           shouldTestClassNameMerging: false,
           shouldTestClassNameOverrides: false,
           shouldTestPropForwarding: false,
-          useComponent2Tests: true);
+          isComponent2: true,
+      );
       });
     });
   });

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -18,6 +18,7 @@ import 'package:over_react_test/over_react_test.dart';
 
 import './utils/test_common_component.dart';
 import './utils/test_common_component_required_props.dart';
+import './utils/test_common_component_required_props_commponent2.dart';
 
 /// Main entry point for [commonComponentTests] testing
 main() {
@@ -30,11 +31,24 @@ main() {
     });
 
     group('should pass when the correct required props are specified', () {
-      commonComponentTests(() => TestCommonRequired()..bar = true,
+      group('when passed a UiComponent', () {
+
+        commonComponentTests(() => TestCommonRequired()..bar = true,
+            shouldTestRequiredProps: true,
+            shouldTestClassNameMerging: false,
+            shouldTestClassNameOverrides: false,
+            shouldTestPropForwarding: false);
+      });
+
+    group('when passed a UiComponent2', () {
+
+      commonComponentTests(() => TestCommonRequired2()..bar = true,
           shouldTestRequiredProps: true,
           shouldTestClassNameMerging: false,
           shouldTestClassNameOverrides: false,
-          shouldTestPropForwarding: false);
+          shouldTestPropForwarding: false,
+          useComponent2Tests: true);
+      });
     });
   });
 }

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -1,0 +1,52 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'test_common_component_required_props_commponent2.over_react.g.dart';
+
+@Factory()
+UiFactory<TestCommonRequiredProps2> TestCommonRequired2 =
+    // ignore: undefined_identifier
+    _$TestCommonRequired2;
+
+@Props()
+class _$TestCommonRequiredProps2 extends UiProps {
+  @requiredProp
+  bool bar;
+}
+
+@Component2()
+class TestCommonRequiredComponent2 extends
+    UiComponent2<TestCommonRequiredProps2> {
+  @override
+  get consumedProps => const [
+    TestCommonRequiredProps2.meta,
+  ];
+
+  @override
+  render() {
+    return (Dom.div()
+      ..modifyProps(addUnconsumedDomProps)
+    )(props.children);
+  }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class TestCommonRequiredProps2 extends _$TestCommonRequiredProps2 with _$TestCommonRequiredProps2AccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForTestCommonRequiredProps2;
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Because `Component2` handles prop validation differently than `Component`, tests relating to prop validation need to be aware of `Component2` in order to test correctly.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a new bool parameter checking for `Component2`
- Add a conditional that changes how props are validated based on the new parameter
- Update dockerfile
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@greglittlefield-wf @kealjones-wk @aaronlademann-wf @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
