### PR TITLE
CPLAT-5662 Release over_react_test 2.5.2 (Includes CPLAT-7562)

### DIFF
--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -61,6 +61,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
   if (container == null) {
     renderedInstance = react_test_utils.renderIntoDocument(component);
   } else {
+    // orcm_ignore
     renderedInstance = react_dom.render(component, container);
   }
 
@@ -161,6 +162,7 @@ List<Element> _attachedReactContainers = [];
     _attachedReactContainers.add(container);
   }
 
+  // orcm_ignore
   return react_dom.render(component is component_base.UiProps ? component.build() : component, container);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.5.1
+version: 2.5.2
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
-  over_react: ">=1.33.1 <3.0.0"
-  react: ^4.7.0
+  over_react: ">=2.4.0 <4.0.0"
+  react: ">=4.7.0 <6.0.0"
   test: ">=0.12.34 <2.0.0"
 dev_dependencies:
   build_runner: ">=0.6.0+1 <2.0.0"


### PR DESCRIPTION
This release adds support for react 5.x and over_react 3.x lines-of-release.

> Full support for react 5.1.0 / over_react 3.1.0 (`Component2`) will be added soon - is currently in the react-16-wip branch.

### QA 

- [ ] Passing CI build
- [ ] Passing CI build for #80