### PR TITLE
CPLAT-7663 CPLAT-7763: commonComponentTests -> testRequiredProps tests are giving false positives

### DIFF
--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -497,16 +497,21 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   test('nullable props', () {
     if (!isComponent2) {
       for (var propKey in nullableProps) {
-        var badRenderer = () => render((factory()..remove(propKey))(childrenFactory()));
+        final reactComponentFactory = factory().componentFactory as
+          ReactDartComponentFactoryProxy; // ignore: avoid_as
+        // Props that are defined in the default props map will never not be set.
+        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+          var badRenderer = () => render((factory()..remove(propKey))(childrenFactory()));
 
-        expect(badRenderer, throwsPropError_Required(propKey, keyToErrorMessage[propKey]), reason: 'should throw when the required, nullable prop $propKey is not set');
+          expect(badRenderer, throwsPropError_Required(propKey, keyToErrorMessage[propKey]), reason: 'should throw when the required, nullable prop $propKey is not set');
 
-        var propsToAdd = {propKey: null};
-        badRenderer = () => render((factory()
-          ..addAll(propsToAdd)
-        )(childrenFactory()));
+          var propsToAdd = {propKey: null};
+          badRenderer = () => render((factory()
+            ..addAll(propsToAdd)
+          )(childrenFactory()));
 
-        expect(badRenderer, returnsNormally, reason: 'does not throw when the required, nullable prop $propKey is set to null');
+          expect(badRenderer, returnsNormally, reason: 'does not throw when the required, nullable prop $propKey is set to null');
+        }
       }
     } else {
       PropTypes.resetWarningCache();

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -393,7 +393,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   // Because Component2's propTypes do not stop the component from
   // rendering with missing required props, an error may need to be caught
   // on mount to keep the tests running.
-  void wrapInTryCatch(Function callback) {
+  void wrapInTryCatch(void callback()) {
     try {
       callback();
     } catch (_){}
@@ -406,7 +406,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
     consumedProps.forEach((ConsumedProps consumedProps) {
       consumedProps.props.forEach((PropDescriptor prop) {
-         if (prop.isNullable) {
+        if (prop.isNullable) {
           nullableProps.add(prop.key);
         } else if (prop.isRequired) {
           requiredProps.add(prop.key);
@@ -513,7 +513,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
         expect(badRenderer, returnsNormally, reason: 'does not throw when the required, nullable prop $propKey is set to null');
       });
-    } else if (isComponent2) {
+    } else {
       PropTypes.resetWarningCache();
 
       List<String> consoleErrors = [];
@@ -526,7 +526,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
       });
 
       final reactComponentFactory = factory().componentFactory as
-      ReactDartComponentFactoryProxy2; // ignore: avoid_as
+          ReactDartComponentFactoryProxy2; // ignore: avoid_as
 
       nullableProps.forEach((String propKey) {
         if (!reactComponentFactory.defaultProps.containsKey(propKey)) {

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -379,8 +379,6 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
   });
 }
 
-
-
 /// Common test for verifying that props annotated as a [requiredProp] are validated correctly.
 ///
 /// > Typically not consumed standalone. Use [commonComponentTests] instead.

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -452,6 +452,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
       List<String> consoleErrors = [];
       JsFunction originalConsoleError = context['console']['error'];
+      addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
         originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
@@ -495,13 +496,10 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
         consoleErrors = [];
         PropTypes.resetWarningCache();
       });
-
-      addTearDown(() => context['console']['error'] = originalConsoleError);
     });
   }
 
   test('nullable props', () {
-
     if (!isComponent2) {
       nullableProps.forEach((String propKey) {
         var badRenderer = () => render((factory()..remove(propKey))(childrenFactory()));
@@ -520,6 +518,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
 
       List<String> consoleErrors = [];
       JsFunction originalConsoleError = context['console']['error'];
+      addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = new JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
         originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
@@ -557,8 +556,6 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
         consoleErrors = [];
         PropTypes.resetWarningCache();
       });
-
-      addTearDown(() => context['console']['error'] = originalConsoleError);
     }
   });
 }

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -43,7 +43,6 @@ main() {
       });
 
     group('when passed a UiComponent2', () {
-
       commonComponentTests(() => (TestCommonRequired2()
             ..bar = true
             ..foobar = true),

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -32,8 +32,9 @@ main() {
 
     group('should pass when the correct required props are specified', () {
       group('when passed a UiComponent', () {
-
-        commonComponentTests(() => TestCommonRequired()..bar = true,
+        commonComponentTests(() => (TestCommonRequired()
+              ..bar = true
+              ..foobar = true),
             shouldTestRequiredProps: true,
             shouldTestClassNameMerging: false,
             shouldTestClassNameOverrides: false,
@@ -43,7 +44,9 @@ main() {
 
     group('when passed a UiComponent2', () {
 
-      commonComponentTests(() => TestCommonRequired2()..bar = true,
+      commonComponentTests(() => (TestCommonRequired2()
+            ..bar = true
+            ..foobar = true),
           shouldTestRequiredProps: true,
           shouldTestClassNameMerging: false,
           shouldTestClassNameOverrides: false,

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -30,6 +30,9 @@ class _$TestCommonRequiredProps extends UiProps {
 
   @requiredProp
   bool bar;
+
+  @requiredProp
+  bool defaultFoo;
 }
 
 @Component()
@@ -38,6 +41,11 @@ class TestCommonRequiredComponent extends UiComponent<TestCommonRequiredProps> {
   get consumedProps => const [
     TestCommonRequiredProps.meta,
   ];
+
+  @override
+  Map getDefaultProps() {
+    return (newProps()..defaultFoo = true);
+  }
 
   @override
   render() {

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -31,7 +31,7 @@ class _$TestCommonRequiredProps extends UiProps {
   @requiredProp
   bool bar;
 
-  @requiredProp
+  @nullableRequiredProp
   bool defaultFoo;
 }
 

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -25,6 +25,9 @@ UiFactory<TestCommonRequiredProps> TestCommonRequired =
 
 @Props()
 class _$TestCommonRequiredProps extends UiProps {
+  @nullableRequiredProp
+  bool foobar;
+
   @requiredProp
   bool bar;
 }

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -30,7 +30,7 @@ class _$TestCommonRequiredProps2 extends UiProps {
   @requiredProp
   bool bar;
 
-  @requiredProp
+  @nullableRequiredProp
   bool defaultFoo;
 }
 

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -29,6 +29,9 @@ class _$TestCommonRequiredProps2 extends UiProps {
 
   @requiredProp
   bool bar;
+
+  @requiredProp
+  bool defaultFoo;
 }
 
 @Component2()
@@ -38,6 +41,9 @@ class TestCommonRequiredComponent2 extends
   get consumedProps => const [
     TestCommonRequiredProps2.meta,
   ];
+
+  @override
+  Map get defaultProps => (newProps()..defaultFoo = true);
 
   @override
   render() {

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -24,6 +24,9 @@ UiFactory<TestCommonRequiredProps2> TestCommonRequired2 =
 
 @Props()
 class _$TestCommonRequiredProps2 extends UiProps {
+  @nullableRequiredProp
+  bool foobar;
+
   @requiredProp
   bool bar;
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Over_react_test's commonComponentTests with shouldTestRequiredProps as true are giving false positives.

The common_component_util.dart file has faulty logic that would never add any propDescriptors too nullableProps leading to the nullable props group/test (that is a foreach loop) to pass because it doesnt iterate over anything.

In addition to the faulty logic the components used to test the test suite dont have props with isNullable so even if the logic was correct our tests still wouldnt have caught it.

## Changes
  <!-- What this PR changes to fix the problem. -->
- fix logic for nullable props
- update test components to include a nullableRequiredProp
- add tests for UiComponent2 to nullable props test

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
