### PR TITLE
Add Component Version Auto Detection

### DIFF
--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -80,6 +80,7 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   bool shouldTestClassNameOverrides = true,
   bool ignoreDomProps = true,
   bool shouldTestRequiredProps = true,
+  @Deprecated('This flag is not needed as the test will auto detect the version')
   bool isComponent2 = false,
   dynamic childrenFactory()
 }) {

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -84,6 +84,7 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   dynamic childrenFactory()
 }) {
   childrenFactory ??= _defaultChildrenFactory;
+  isComponent2 = ReactDartComponentVersion.fromType((factory()()).type) == '2' || isComponent2;
 
   Iterable flatten(Iterable iterable) =>
       iterable.expand((item) => item is Iterable ? flatten(item) : [item]);
@@ -388,7 +389,6 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   var keyToErrorMessage = {};
   var nullableProps = <String>[];
   var requiredProps = <String>[];
-  final isAutoDetectedAsComponent2 = ReactDartComponentVersion.fromType((factory()()).type) == '2';
 
   setUp(() {
     var jacket = mount(factory()(childrenFactory()), autoTearDown: false);
@@ -412,7 +412,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
     consumedProps.forEach(iterateOverProps);
   });
 
-  if (!isComponent2 && !isAutoDetectedAsComponent2) {
+  if (!isComponent2) {
     test('throws when the required prop is not set or is null', () {
         for (var propKey in requiredProps) {
           final reactComponentFactory = factory()
@@ -499,7 +499,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   }
 
   test('nullable props', () {
-    if (!isComponent2 && !isAutoDetectedAsComponent2) {
+    if (!isComponent2) {
       for (var propKey in nullableProps) {
         final reactComponentFactory = factory().componentFactory as
           ReactDartComponentFactoryProxy; // ignore: avoid_as

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -388,6 +388,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   var keyToErrorMessage = {};
   var nullableProps = <String>[];
   var requiredProps = <String>[];
+  final isAutoDetectedAsComponent2 = ReactDartComponentVersion.fromType((factory()()).type) == '2';
 
   setUp(() {
     var jacket = mount(factory()(childrenFactory()), autoTearDown: false);
@@ -411,7 +412,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
     consumedProps.forEach(iterateOverProps);
   });
 
-  if (!isComponent2) {
+  if (!isComponent2 && !isAutoDetectedAsComponent2) {
     test('throws when the required prop is not set or is null', () {
         for (var propKey in requiredProps) {
           final reactComponentFactory = factory()
@@ -498,7 +499,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory(),
   }
 
   test('nullable props', () {
-    if (!isComponent2) {
+    if (!isComponent2 && !isAutoDetectedAsComponent2) {
       for (var propKey in nullableProps) {
         final reactComponentFactory = factory().componentFactory as
           ReactDartComponentFactoryProxy; // ignore: avoid_as

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -49,7 +49,6 @@ main() {
           shouldTestClassNameMerging: false,
           shouldTestClassNameOverrides: false,
           shouldTestPropForwarding: false,
-          isComponent2: true,
       );
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Currently the common component tests require the flag `isComponent2` to be set to true in order to run tests specific to `Component2`. This can be automated, eliminating the need for the flag to be set.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a check to the `ReactElement` type to determine if the version is one or two.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Add automated `ReactElement` type check to `commonComponentTests`.
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @kealjones-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] Publink this branch to web_skin_dart's react-16-post-upgrade-wip branch and run a `Component2` test suite without setting the `isComponent2` flag.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
