### PR TITLE
CPLAT-8702 Update test utilities to use the current zone

### DIFF
--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -21,7 +21,7 @@ import 'package:react/react_test_utils.dart' as react_test_utils;
 
 import 'package:over_react_test/src/over_react_test/react_util.dart' as react_util;
 
-import '../../over_react_test.dart';
+import './zone_util.dart';
 
 // Notes
 // ---------------------------------------------------------------------------

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:html';
 
 import 'package:over_react/over_react.dart' as over_react;
 import 'package:react/react.dart' as react;
-import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart' show ReactComponent;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 
 import 'package:over_react_test/src/over_react_test/react_util.dart' as react_util;
+
+import '../../over_react_test.dart';
 
 // Notes
 // ---------------------------------------------------------------------------
@@ -74,8 +74,8 @@ class TestJacket<T extends react.Component> {
   bool _isMounted = false;
 
   void _render(over_react.ReactElement reactElement) {
-    // ignore: invalid_use_of_visible_for_testing_member
-    currentComponentZone = Zone.current;
+    setComponentZone();
+
     _isMounted = true;
     _renderedInstance = attachedToDocument
         ? react_util.renderAttachedToDocument(reactElement,

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:html';
 
 import 'package:over_react/over_react.dart' as over_react;
 import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart' show ReactComponent;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 
@@ -72,6 +74,8 @@ class TestJacket<T extends react.Component> {
   bool _isMounted = false;
 
   void _render(over_react.ReactElement reactElement) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    currentComponentZone = Zone.current;
     _isMounted = true;
     _renderedInstance = attachedToDocument
         ? react_util.renderAttachedToDocument(reactElement,

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -15,7 +15,6 @@
 @JS()
 library over_react_test.react_util;
 
-import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
@@ -29,6 +28,8 @@ import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_test_utils.dart' as react_test_utils;
 import 'package:test/test.dart';
+
+import '../../over_react_test.dart';
 
 export 'package:over_react/src/util/react_wrappers.dart';
 
@@ -59,8 +60,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
   var renderedInstance;
   component = component is component_base.UiProps ? component.build() : component;
 
-  // ignore: invalid_use_of_visible_for_testing_member
-  currentComponentZone = Zone.current;
+  setComponentZone();
 
   if (container == null) {
     renderedInstance = react_test_utils.renderIntoDocument(component);
@@ -156,8 +156,7 @@ List<Element> _attachedReactContainers = [];
     ..style.setProperty('width', '800px')
     ..style.setProperty('height', '800px');
 
-  // ignore: invalid_use_of_visible_for_testing_member
-  currentComponentZone = Zone.current;
+  setComponentZone();
 
   document.body.append(container);
 

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -15,6 +15,7 @@
 @JS()
 library over_react_test.react_util;
 
+import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
@@ -58,10 +59,12 @@ export 'package:over_react/src/util/react_wrappers.dart';
   var renderedInstance;
   component = component is component_base.UiProps ? component.build() : component;
 
+  // ignore: invalid_use_of_visible_for_testing_member
+  currentComponentZone = Zone.current;
+
   if (container == null) {
     renderedInstance = react_test_utils.renderIntoDocument(component);
   } else {
-    // orcm_ignore
     renderedInstance = react_dom.render(component, container);
   }
 
@@ -153,6 +156,9 @@ List<Element> _attachedReactContainers = [];
     ..style.setProperty('width', '800px')
     ..style.setProperty('height', '800px');
 
+  // ignore: invalid_use_of_visible_for_testing_member
+  currentComponentZone = Zone.current;
+
   document.body.append(container);
 
   if (autoTearDown) {
@@ -165,7 +171,6 @@ List<Element> _attachedReactContainers = [];
     _attachedReactContainers.add(container);
   }
 
-  // orcm_ignore
   return react_dom.render(component is component_base.UiProps ? component.build() : component, container);
 }
 

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:react/react_client.dart';
 import 'package:test/test.dart';
 
 Zone _zone;
@@ -43,4 +44,12 @@ void zonedExpect(actual, matcher, {String reason}) {
   return _zone.run(() {
     expect(actual, matcher, reason: reason);
   });
+}
+
+/// Sets the zone that React components are run in.
+///
+/// By default, tests and React run in differing zones. This can be used to force
+/// tests and components to be run in the same zone.
+void setComponentZone([Zone zone]) {
+  componentZone = zone ?? Zone.current;
 }

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -50,6 +50,29 @@ void zonedExpect(actual, matcher, {String reason}) {
 ///
 /// By default, tests and React run in differing zones. This can be used to force
 /// tests and components to be run in the same zone.
+///
+/// __NOTE:__ This is not needed when using `render` (or any function that
+/// utilizes it) or `mount` because it is built in to those utilities.
+///
+/// __EXAMPLE:__
+///
+///     test('test that requires zones to be the same', () {
+///       // Reset the zone back to the default after the test is run.
+///       addTearDown(() => setComponentZone(Zone.root));
+///
+///       void shouldFailTest() => expect(true, isFalse);
+///       void shouldPassTest() => expect(true, isTrue);
+///
+///       renderIntoDocument((
+///           TestComponent()..onComponentDidMount = shouldFailTest)()); // Throws bad state error
+///
+///       setComponentZone();
+///
+///       renderIntoDocument((
+///           TestComponent()..onComponentDidMount = shouldFailTest)()); // Fails
+///       renderIntoDocument((
+///           TestComponent()..onComponentDidMount = shouldPassTest)()); // Passes
+///     });
 void setComponentZone([Zone zone]) {
   componentZone = zone ?? Zone.current;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:cleandart/react-dart.git
+      url: https://github.com/cleandart/react-dart.git
       ref: CPLAT-8698-expose-componentZone
 
 transformers:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   over_react: ^3.1.3
-  react: ^5.1.2
+  react: ^5.2.0
   test: ^1.9.1
 dev_dependencies:
   build_runner: ^1.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,12 @@ dev_dependencies:
   dependency_validator: ^1.4.0
   pedantic: ^1.8.0
 
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:cleandart/react-dart.git
+      ref: CPLAT-8698-expose-componentZone
+
 transformers:
   - over_react
   - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   over_react: ^3.1.3
-  react: ^5.1.0
+  react: ^5.1.2
   test: ^1.9.1
 dev_dependencies:
   build_runner: ^1.7.1
@@ -19,12 +19,6 @@ dev_dependencies:
   dart_dev: ^2.2.0
   dependency_validator: ^1.4.0
   pedantic: ^1.8.0
-
-dependency_overrides:
-  react:
-    git:
-      url: https://github.com/cleandart/react-dart.git
-      ref: CPLAT-8698-expose-componentZone
 
 transformers:
   - over_react

--- a/test/over_react_test.dart
+++ b/test/over_react_test.dart
@@ -26,6 +26,7 @@ import 'over_react_test/dom_util_test.dart' as test_util_dom_util_test;
 import 'over_react_test/jacket_test.dart' as jacket_test;
 import 'over_react_test/react_util_test.dart' as react_util_test;
 import 'over_react_test/validation_util_test.dart' as validation_util_test;
+import 'over_react_test/zone_render_tests.dart' as zone_render_tests;
 
 main() {
   setClientConfiguration();
@@ -39,4 +40,5 @@ main() {
   jacket_test.main();
   react_util_test.main();
   validation_util_test.main();
+  zone_render_tests.main();
 }

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -172,7 +172,7 @@ main() {
 
     test('handles errors as expected when mounting', () {
       var logs = recordConsoleLogs(
-          () => mount((Sample()..shouldError = true)()),
+          () => mount((Sample()..shouldErrorInRender = true)()),
           configuration: errorConfig);
 
       expect(logs, hasLength(2));
@@ -233,7 +233,7 @@ main() {
         mount(
             (Sample()
               ..shouldAlwaysBeFalse = true
-              ..shouldError = true)(),
+              ..shouldErrorInRender = true)(),
             attachedToDocument: true);
       }, configuration: errorConfig);
 
@@ -248,7 +248,7 @@ main() {
         await Future.delayed(Duration(milliseconds: 5));
 
         jacket.rerender((Sample()
-          ..shouldError = true
+          ..shouldErrorInRender = true
           ..shouldAlwaysBeFalse = true)());
       }, configuration: errorConfig);
 

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -25,7 +25,7 @@ class _$SampleProps extends UiProps {
 
   bool addExtraLogAndWarn;
 
-  Function() componentDidMountCallback;
+  Function() onComponentDidMount;
 
   bool shouldLog;
 }
@@ -71,7 +71,7 @@ class SampleComponent extends UiComponent2<SampleProps> {
   componentDidMount() {
     window.console.warn('Just a lil warning');
     if (props.shouldErrorInMount) throw Error();
-    props.componentDidMountCallback?.call();
+    props.onComponentDidMount?.call();
   }
 
   @override

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -71,7 +71,7 @@ class SampleComponent extends UiComponent2<SampleProps> {
   componentDidMount() {
     window.console.warn('Just a lil warning');
     if (props.shouldErrorInMount) throw Error();
-    if (props.componentDidMountCallback != null) props.componentDidMountCallback();
+    props.componentDidMountCallback?.call();
   }
 
   @override

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -17,9 +17,15 @@ class _$SampleProps extends UiProps {
 
   bool shouldAlwaysBeFalse;
 
-  bool shouldError;
+  bool shouldErrorInRender;
+
+  bool shouldErrorInMount;
+
+  bool shouldErrorInUnmount;
 
   bool addExtraLogAndWarn;
+
+  Function() componentDidMountCallback;
 
   bool shouldLog;
 }
@@ -29,7 +35,9 @@ class SampleComponent extends UiComponent2<SampleProps> {
   @override
   Map get defaultProps => (newProps()
     ..shouldAlwaysBeFalse = false
-    ..shouldError = false
+    ..shouldErrorInRender = false
+    ..shouldErrorInMount = false
+    ..shouldErrorInUnmount = false
     ..addExtraLogAndWarn = false
     ..shouldLog = true);
 
@@ -62,12 +70,14 @@ class SampleComponent extends UiComponent2<SampleProps> {
   @override
   componentDidMount() {
     window.console.warn('Just a lil warning');
+    if (props.shouldErrorInMount) throw Error();
+    if (props.componentDidMountCallback != null) props.componentDidMountCallback();
   }
 
   @override
   render() {
     window.console.warn('A second warning');
-    if (props.shouldError) {
+    if (props.shouldErrorInRender) {
       throw Error();
     } else {
       if (props.addExtraLogAndWarn) {
@@ -88,6 +98,13 @@ class SampleComponent extends UiComponent2<SampleProps> {
   void _handleOnClick(_) {
     window.console.log('Clicking');
     window.console.warn('I have been clicked');
+  }
+
+  @override
+  void componentWillUnmount() {
+    super.componentWillUnmount();
+
+    if (props.shouldErrorInUnmount) throw Error();
   }
 }
 

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -27,14 +27,16 @@ void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) r
       setComponentZone(Zone.root);
     });
 
-    test('Failing expects work in Component2 lifecycle methods', () {
+    test(
+        'Component lifecycle methods can call `expect` statements passed in within a callback',
+        () {
       void testCallback() {
         expect(true, isFalse);
       }
 
       shouldFail(
           () => renderFunction(
-              (Sample()..componentDidMountCallback = testCallback)()),
+              (Sample()..onComponentDidMount = testCallback)()),
           returnsNormally,
           contains('threw TestFailure'));
     });

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -51,7 +51,6 @@ void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) r
         test('', () {
           if (!shouldError) {
             tryCount++;
-            expect(true, isTrue);
           } else {
             shouldError = false;
             tryCount++;
@@ -76,13 +75,11 @@ void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) r
           test('', () {
             if (!shouldError) {
               tryCount++;
-              expect(true, isTrue);
             } else {
               shouldError = false;
               tryCount++;
               componentInstance =
                   renderFunction((Sample()..shouldErrorInUnmount = true)(), autoTearDown: false);
-              expect(true, isTrue);
             }
 
             componentInstance is TestJacket
@@ -110,13 +107,11 @@ void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) r
           test('', () {
             if (!shouldError) {
               tryCount++;
-              expect(true, isTrue);
             } else {
               shouldError = false;
               tryCount++;
               componentInstance =
                   renderFunction((Sample()..shouldErrorInUnmount = true)(), autoTearDown: false);
-              expect(true, isTrue);
             }
           }, retry: 2);
 

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -1,0 +1,107 @@
+import 'package:over_react_test/over_react_test.dart';
+import 'package:test/test.dart';
+
+import 'custom_matchers_test.dart';
+import 'helper_components/sample_component.dart';
+
+main() {
+  group('TestJacket mount', () {
+    sharedZoneRenderTests((component, {autoTeardown = true}) =>
+        mount(component, autoTearDown: autoTeardown));
+  });
+
+  group('render', () {
+    sharedZoneRenderTests((component, {autoTeardown = true}) =>
+        render(component, autoTearDown: autoTeardown));
+  });
+
+  group('renderAttachedToDocument', () {
+    sharedZoneRenderTests((component, {autoTeardown = true}) =>
+        renderAttachedToDocument(component, autoTearDown: autoTeardown));
+  });
+}
+
+void sharedZoneRenderTests(Function renderFunction) {
+  group('sharedZoneRenderTests:', () {
+    test('Failing expects work in Component2 lifecycle methods', () {
+      void testCallback() {
+        expect(true, isFalse);
+      }
+
+      shouldFail(
+          () => renderFunction(
+              (Sample()..componentDidMountCallback = testCallback)()),
+          returnsNormally,
+          contains('threw TestFailure'));
+    });
+
+    group('Errors thrown when unmounting fail tests', () {
+      // For this group, we need to test that an error is thrown during test
+      // teardown. To do that, we rely on an error being thrown during unmount,
+      // failing a test that should pass. The test also mutates variables outside
+      // its local scope. We can then verify that those variables show that the
+      // test had to be retried.
+      var unmountThrewError = false;
+      var tryCount = 0;
+
+      group('when the unmount happens automatically', () {
+        tearDownAll(() {
+          unmountThrewError = false;
+          tryCount = 0;
+        });
+
+        test('', () {
+          if (unmountThrewError) {
+            tryCount++;
+            expect(true, isTrue);
+          } else {
+            unmountThrewError = true;
+            tryCount++;
+            renderFunction((Sample()..shouldErrorInUnmount = true)());
+            expect(true, isTrue);
+          }
+        }, retry: 2);
+
+        test('verify a retry was needed to pass the last test', () {
+          expect(tryCount, 2);
+          expect(unmountThrewError, isTrue);
+        });
+      });
+
+      group('when the unmount happens explicitly', () {
+        dynamic componentInstance;
+
+        tearDown(() {
+          try {
+            if (componentInstance != null) componentInstance.unmount();
+          } on NoSuchMethodError {
+            unmount(componentInstance);
+          }
+        });
+
+        tearDownAll(() {
+          unmountThrewError = false;
+          tryCount = 0;
+        });
+
+        test('', () {
+          if (unmountThrewError) {
+            tryCount++;
+            expect(true, isTrue);
+          } else {
+            unmountThrewError = true;
+            tryCount++;
+            componentInstance =
+                renderFunction((Sample()..shouldErrorInUnmount = true)());
+            expect(true, isTrue);
+          }
+        }, retry: 2);
+
+        test('verify a retry was needed to pass the last test', () {
+          expect(tryCount, 2);
+          expect(unmountThrewError, isTrue);
+        });
+      });
+    });
+  });
+}

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:over_react_test/over_react_test.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:test/test.dart';
@@ -21,6 +23,10 @@ main() {
 
 void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) renderFunction) {
   group('sharedZoneRenderTests:', () {
+    setUp(() {
+      setComponentZone(Zone.root);
+    });
+
     test('Failing expects work in Component2 lifecycle methods', () {
       void testCallback() {
         expect(true, isFalse);

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -35,27 +35,27 @@ void sharedZoneRenderTests(Function renderFunction) {
           contains('threw TestFailure'));
     });
 
-    group('Errors thrown when unmounting fail tests', () {
+    group('Errors thrown when unmounting fails tests', () {
       // For this group, we need to test that an error is thrown during test
       // teardown. To do that, we rely on an error being thrown during unmount,
       // failing a test that should pass. The test also mutates variables outside
       // its local scope. We can then verify that those variables show that the
       // test had to be retried.
-      var unmountThrewError = false;
+      var shouldError = true;
       var tryCount = 0;
 
       group('when the unmount happens automatically', () {
         tearDownAll(() {
-          unmountThrewError = false;
+          shouldError = true;
           tryCount = 0;
         });
 
         test('', () {
-          if (unmountThrewError) {
+          if (!shouldError) {
             tryCount++;
             expect(true, isTrue);
           } else {
-            unmountThrewError = true;
+            shouldError = false;
             tryCount++;
             renderFunction((Sample()..shouldErrorInUnmount = true)());
             expect(true, isTrue);
@@ -64,7 +64,6 @@ void sharedZoneRenderTests(Function renderFunction) {
 
         test('verify a retry was needed to pass the last test', () {
           expect(tryCount, 2);
-          expect(unmountThrewError, isTrue);
         });
       });
 
@@ -80,16 +79,16 @@ void sharedZoneRenderTests(Function renderFunction) {
         });
 
         tearDownAll(() {
-          unmountThrewError = false;
+          shouldError = true;
           tryCount = 0;
         });
 
         test('', () {
-          if (unmountThrewError) {
+          if (!shouldError) {
             tryCount++;
             expect(true, isTrue);
           } else {
-            unmountThrewError = true;
+            shouldError = false;
             tryCount++;
             componentInstance =
                 renderFunction((Sample()..shouldErrorInUnmount = true)());
@@ -99,7 +98,6 @@ void sharedZoneRenderTests(Function renderFunction) {
 
         test('verify a retry was needed to pass the last test', () {
           expect(tryCount, 2);
-          expect(unmountThrewError, isTrue);
         });
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Our current render utilities mount the component using a different zone then that of the test. We want to make them the same zone.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Update `mount`, `render`, and `renderAttachedToDocument` to use set `currentComponentZone` to `Zone.current`.
- Add tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Update `mount`, `render`, and `renderAttachedToDocument` to run in the same zone as the test.
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @kealjones-wk @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
       - None! 🎉 
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
