### PR TITLE
RM-62263 Release over_react_test 2.7.1

### DIFF
--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -71,6 +71,9 @@ class TestJacket<T extends react.Component> {
   final bool autoTearDown;
   bool _isMounted = false;
 
+  bool get _isCompositeComponent => react_test_utils.isCompositeComponent(_renderedInstance);
+  bool get _isDomComponent => react_test_utils.isDOMComponent(_renderedInstance);
+
   void _render(over_react.ReactElement reactElement) {
     _isMounted = true;
     _renderedInstance = attachedToDocument
@@ -89,28 +92,90 @@ class TestJacket<T extends react.Component> {
     _render(reactElement);
   }
 
-  /// Returns the mounted React component instance.
+  /// Returns the mounted React composite component instance.
+  ///
+  /// > If you are rendering a function component using [mount], calling [getInstance] will throw a `StateError`.
+  /// >
+  /// > * If you are trying to access an instance rendered by the function component:
+  /// >   * Use `forwardRef` to pass refs through the tree.
+  /// > * If you are trying to access / query for a DOM node rendered by the function component, try using:
+  /// >
+  /// >   ```
+  /// >   queryByTestId(jacket.mountNode, yourTestId)
+  /// >   ```
   ReactComponent getInstance() {
-    if (!react_test_utils.isCompositeComponent(_renderedInstance)) {
-      throw UnsupportedError('Not a composite component');
+    // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
+    //     a DOM component (Element) - does not throw. The cast to `ReactComponent` - while not "sound", is harmless
+    //     since it is an anonymous JS interop class - not a Dart type.
+    if (!_isCompositeComponent && /*[1]*/!_isDomComponent) {
+      throw StateError(
+          'getInstance() is only supported when the rendered object is a composite (class based) component. '
+          'If you are rendering a function component, and are trying to:\n\n'
+          '1. Access an instance rendered by the function component: use `forwardRef` to pass refs through the tree.\n'
+          '2. Access / query for a DOM node rendered by the function component: try using\n'
+          '    queryByTestId(jacket.mountNode, yourTestId)');
     }
 
     return _renderedInstance as ReactComponent;
   }
 
-  /// Returns the props associated with the mounted React component instance.
+  /// Returns the props associated with the mounted React composite component instance.
+  ///
+  /// > If you are rendering a function component using [mount], calling [getProps] will throw a `StateError`.
+  /// >
+  /// > See [getInstance] for more information about this limitation.
   Map getProps() {
+    if (!_isCompositeComponent) {
+      throw StateError(
+          'getProps() is only supported when the rendered object is a composite (class based) component.');
+    }
+
     return over_react.getProps(getInstance());
   }
 
-  /// Returns the DOM node associated with the mounted React component instance.
+  /// Returns the DOM node associated with the mounted React composite / DOM component instance.
+  ///
+  /// > If you are rendering a function component using [mount], calling [getNode] will throw a `StateError`.
+  /// >
+  /// > Try using one of the following instead:
+  /// >
+  /// > ```
+  /// > jacket.mountNode.querySelector(someSelectorThatTargetsTheRootNode);
+  /// > ```
+  /// >
+  /// > ```
+  /// > queryByTestId(jacket.mountNode, yourRootNodeTestId);
+  /// > ```
   Element getNode() {
+    if (!_isCompositeComponent && !_isDomComponent) {
+      throw StateError(
+          'getNode() is only supported when the rendered object is a DOM or composite (class based) component. '
+          'If you are rendering a function component, try using \n'
+          '    jacket.mountNode.querySelector(someSelectorThatTargetsTheRootNode) \n'
+          '    // or'
+          '    queryByTestId(jacket.mountNode, yourRootNodeTestId)');
+    }
+
     return over_react.findDomNode(_renderedInstance);
   }
 
-  /// Returns the native Dart component associated with the mounted React component instance, or null if the component
-  /// is not Dart based.
+  /// Returns the native Dart component associated with the mounted React composite component instance,
+  /// or null if the component is not Dart based.
+  ///
+  /// > If you are rendering a function component using [mount], calling [getDartInstance] will throw a `StateError`.
+  /// >
+  /// > See [getInstance] for more information about this limitation.
   T getDartInstance() {
+    // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
+    //     a DOM component (Element) - is to return `null`. While that will most likely cause null exceptions once the
+    //     consumer attempts to make a call on the "Dart instance" they have requested - we don't want this change
+    //     to cause new exceptions in a scenario where the consumer was storing a null value and then simply
+    //     not using it in their test.
+    if (!_isCompositeComponent && /*[1]*/!_isDomComponent) {
+      throw StateError(
+          'getDartInstance() is only supported when the rendered object is a composite (class based) component.');
+    }
+
     return over_react.getDartComponent(_renderedInstance) as T;
   }
 
@@ -124,7 +189,16 @@ class TestJacket<T extends react.Component> {
   /// Also allows [newState] to be used as a transactional `setState` callback.
   ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
+  ///
+  /// > If you are rendering a function component using [mount], calling [setState] will throw a `StateError`.
+  /// >
+  /// > See [getInstance] for more information about this limitation.
   void setState(newState, [callback()]) {
+    if (!_isCompositeComponent) {
+      throw StateError(
+          'setState() is only supported when the rendered object is a composite (class based) component.');
+    }
+
     getDartInstance().setState(newState, callback);
   }
 

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -121,7 +121,7 @@ class TestJacket<T extends react.Component> {
 
   /// Returns the props associated with the mounted React composite component instance.
   ///
-  /// > If you are rendering a function component using [mount], calling [getProps] will throw a `StateError`.
+  /// > If you are rendering a function or DOM component using [mount], calling [getProps] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
   Map getProps() {
@@ -190,7 +190,7 @@ class TestJacket<T extends react.Component> {
   ///
   /// See: <https://facebook.github.io/react/docs/react-component.html#setstate>
   ///
-  /// > If you are rendering a function component using [mount], calling [setState] will throw a `StateError`.
+  /// > If you are rendering a function or DOM component using [mount], calling [setState] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
   void setState(newState, [callback()]) {

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -129,14 +129,43 @@ void unmount(dynamic instanceOrContainerNode) {
 ///
 /// By default the rendered instance will be unmounted after the current test, to prevent this behavior set
 /// [autoTearDown] to false.
+///
+/// > If [component] is a function component, calling [renderAndGetDom] will throw a `StateError`.
+/// >
+/// > See `TestJacket.getNode` for more information about this limitation.
 Element renderAndGetDom(dynamic component, {bool autoTearDown = true, Callback autoTearDownCallback}) {
-  return findDomNode(render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback));
+  final renderedInstance = render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback);
+
+  if (!react_test_utils.isCompositeComponent(renderedInstance) && !react_test_utils.isDOMComponent(renderedInstance)) {
+    throw StateError(
+      'renderAndGetDom() is only supported when the rendered object is a DOM or composite (class based) component.');
+  }
+
+  return findDomNode(renderedInstance);
 }
 
-/// Renders a React component or builder into a detached node and returns the associtated Dart component.
+/// Renders a React component or builder into a detached node and returns the associated Dart component.
+///
+/// > If [component] is a function component, calling [renderAndGetComponent] will throw a `StateError`.
+/// >
+/// > See `TestJacket.getInstance` for more information about this limitation.
 react.Component renderAndGetComponent(dynamic component,
-        {bool autoTearDown = true, Callback autoTearDownCallback}) =>
-    getDartComponent(render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback));
+        {bool autoTearDown = true, Callback autoTearDownCallback}) {
+  final renderedInstance = render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback);
+
+  // [1] Adding an additional check for dom components here because the current behavior when `renderedInstance` is
+  //     a DOM component (Element) - is to return `null`. While that will most likely cause null exceptions once the
+  //     consumer attempts to make a call on the "Dart instance" they have requested - we don't want this change
+  //     to cause new exceptions in a scenario where the consumer was storing a null value and then simply
+  //     not using it in their test.
+  if (!react_test_utils.isCompositeComponent(renderedInstance) &&
+      /*[1]*/!react_test_utils.isDOMComponent(renderedInstance)) {
+    throw StateError(
+      'renderAndGetComponent() is only supported when the rendered object is a composite (class based) component.');
+  }
+
+  return getDartComponent(renderedInstance);
+}
 
 /// List of elements attached to the DOM and used as mount points in previous calls to [renderAttachedToDocument].
 List<Element> _attachedReactContainers = [];
@@ -238,7 +267,7 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// This method works for:
 ///
-/// * `ReactComponent` render trees (output of [render])
+/// * `ReactComponent` (composite component) render trees (output of [render])
 /// * [ReactElement] trees (output of [renderShallow]/`Component.render`)
 ///
 /// __Example:__

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.7.0
+version: 2.7.1
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   over_react: ^3.1.3
-  react: ^5.1.0
+  react: ^5.2.1
   test: ^1.9.1
 dev_dependencies:
   build_runner: ^1.7.1

--- a/test/over_react_test/helper_components/sample_function_component.dart
+++ b/test/over_react_test/helper_components/sample_function_component.dart
@@ -1,0 +1,30 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:js/js.dart';
+import 'package:react/react.dart' as react;
+import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_client/js_backed_map.dart';
+
+final testFunctionComponent = ([Map props = const {}]) => React.createElement(allowInterop((jsProps, _) {
+  return react.div({...JsBackedMap.fromJs(jsProps), 'isRenderResult': true});
+}), JsBackedMap.from(props).jsObject);
+
+// TODO: Replace the above code with the registerFunctionComponent version below once react 5.3.0 is released.
+//final testFunctionComponent = react.registerFunctionComponent(_TestFunctionComponent,
+//  displayName: 'testFunctionComponent');
+//
+//_TestFunctionComponent(Map props) {
+//  return react.div({...props, 'isRenderResult': true});
+//}

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -18,6 +18,8 @@ import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
 import 'package:over_react_test/over_react_test.dart';
 
+import 'helper_components/sample_function_component.dart';
+
 // ignore: uri_has_not_been_generated
 part 'jacket_test.over_react.g.dart';
 
@@ -167,7 +169,7 @@ main() {
     });
   });
 
-  group('TestJacket:', () {
+  group('TestJacket: composite component:', () {
     TestJacket<SampleComponent> jacket;
 
     setUp(() {
@@ -203,6 +205,106 @@ main() {
       jacket.setState(jacket.getDartInstance().newState()..bar = true);
 
       expect(jacket.getDartInstance().state.bar, isTrue);
+    });
+
+    test('unmount', () {
+      expect(jacket.isMounted, isTrue);
+
+      jacket.unmount();
+
+      expect(jacket.isMounted, isFalse);
+    });
+  });
+
+  group('TestJacket: DOM component:', () {
+    Element mountNode;
+    TestJacket jacket;
+
+    setUp(() {
+      mountNode = DivElement();
+      jacket = mount(Dom.span()(),
+        mountNode: mountNode,
+        attachedToDocument: true
+      );
+
+      expect(mountNode.children.single, isA<SpanElement>());
+    });
+
+    tearDown(() {
+      mountNode.remove();
+      mountNode = null;
+    });
+
+    test('rerender', () {
+      jacket.rerender((Dom.span()..id = 'foo')());
+
+      expect(mountNode.children.single.id, 'foo');
+    });
+
+    test('getProps throws a StateError', () {
+      expect(() => jacket.getProps(), throwsStateError);
+    });
+
+    test('getNode', () {
+      expect(jacket.getNode(), mountNode.children.single);
+    });
+
+    test('getDartInstance returns null', () {
+      expect(jacket.getDartInstance(), isNull);
+    });
+
+    test('setState throws a StateError', () {
+      expect(() => jacket.setState({}), throwsStateError);
+    });
+
+    test('unmount', () {
+      expect(jacket.isMounted, isTrue);
+
+      jacket.unmount();
+
+      expect(jacket.isMounted, isFalse);
+    });
+  });
+
+  group('TestJacket: function component:', () {
+    Element mountNode;
+    TestJacket jacket;
+
+    setUp(() {
+      mountNode = DivElement();
+      jacket = mount(testFunctionComponent({'id': 'foo'}),
+        mountNode: mountNode,
+        attachedToDocument: true
+      );
+
+      expect(mountNode.children.single.id, 'foo');
+    });
+
+    tearDown(() {
+      mountNode.remove();
+      mountNode = null;
+    });
+
+    test('rerender', () {
+      jacket.rerender(testFunctionComponent({'id': 'bar'}));
+
+      expect(mountNode.children.single.id, 'bar');
+    });
+
+    test('getProps throws a StateError', () {
+      expect(() => jacket.getProps(), throwsStateError);
+    });
+
+    test('getNode throws a StateError', () {
+      expect(() => jacket.getNode(), throwsStateError);
+    });
+
+    test('getDartInstance throws a StateError', () {
+      expect(() => jacket.getDartInstance(), throwsStateError);
+    });
+
+    test('setState throws a StateError', () {
+      expect(() => jacket.setState({}), throwsStateError);
     });
 
     test('unmount', () {

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -20,7 +20,8 @@ import 'package:react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as rtu;
 import 'package:test/test.dart';
 
-import './utils/nested_component.dart';
+import 'helper_components/sample_function_component.dart';
+import 'utils/nested_component.dart';
 
 // ignore: uri_has_not_been_generated
 part 'react_util_test.over_react.g.dart';
@@ -90,6 +91,34 @@ main() {
       );
 
       expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
+    });
+
+    group('renderAndGetDom', () {
+      test('renders and returns the root node of a composite component', () {
+        expect(renderAndGetDom(Test()()), isA<Element>());
+      });
+
+      test('renders and returns a Dom component node', () {
+        expect(renderAndGetDom(Dom.div()()), isA<Element>());
+      });
+
+      test('throws a StateError if the provided component is a function component', () {
+        expect(() => renderAndGetDom(testFunctionComponent({})), throwsStateError);
+      });
+    });
+
+    group('renderAndGetComponent', () {
+      test('renders and returns a Dart component instance when a composite component is provided', () {
+        expect(renderAndGetComponent(Test()()), isA<TestComponent>());
+      });
+
+      test('renders and returns null when a DOM component is provided', () {
+        expect(renderAndGetComponent(Dom.div()()), isNull);
+      });
+
+      test('throws a StateError if the provided component is a function component', () {
+        expect(() => renderAndGetComponent(testFunctionComponent({})), throwsStateError);
+      });
     });
 
     group('click', () {


### PR DESCRIPTION
This patch includes improved error messages that are sent to the user when they attempt to test function components in an unsupported way.

---

@kealjones-wk @joebingham-wk @greglittlefield-wf 