### PR TITLE
RM-63477 Release over_react_test 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Test Changelog
 
+## 2.8.0
+* Update mount, render, and renderAttachedToDocument to automatically run component lifecycle in the same zone as the test.
+    * This fixes some `print` statements from being swallowed and some failing `expect`s from not failing tests properly
+
 ## 2.7.0
 * Add propTypes testing utilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 # OverReact Test Changelog
 
-## 2.0.0
+## 2.7.0
+* Add propTypes testing utilities
+
+## 2.6.0
+* Drop support for React 15 
+* Support Component2 in commonComponentTests
+
+## 2.5.2
+* Add support for React 16 (raise upper bound of `react` to allow 5.x, `over_react` to allow 3.x)
+* Fix documentation link
+
+## 2.5.1
+* Accommodate findAllInRenderedTree being passed text nodes in React 16
+
+## 2.5.0
+* Update references to old JS interop helpers
+* Update contributing docs
+
+## 2.4.1
+* Work around a bug in DDC where SvgElement className isn't String
+
+## 2.3.0
+* Widen over_react range to allow 2.0.0
+
+## 2.2.0
+* Update component boilerplate in preparation for over_react 2.0.0
+
+## 2.1.0
+* Update component boilerplate in preparation for over_react 2.0.0
 
 __New Features__
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.7.1
+version: 2.8.0
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-8702 Update test utilities to use the current zone](https://github.com/Workiva/over_react_test/pull/92)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/2.7.1...Workiva:release_over_react_test_2.8.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/2.7.1...2.8.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)