### PR TITLE
CPLAT-10387 CPLAT-3700 Re-instate prop forwarding tests for new boilerplate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.5 as dart2
+FROM google/dart:2.7 as dart2
 # Build Environment Vars
 ARG BUILD_ID
 ARG BUILD_NUMBER

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -101,6 +101,9 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
         skippedPropKeys = getSkippedPropKeys(meta);
       }
 
+      unconsumedPropKeys = _flatten(unconsumedPropKeys).toList();
+      skippedPropKeys = _flatten(skippedPropKeys).toList();
+
       _testPropForwarding(
         factory,
         childrenFactory,

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -91,30 +91,32 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   childrenFactory ??= _defaultChildrenFactory;
   isComponent2 = ReactDartComponentVersion.fromType((factory()()).type) == '2' || isComponent2;
 
-  final meta = getPropsMeta(factory()(childrenFactory()));
-  if (meta != null) {
-    if (getUnconsumedPropKeys != null) {
-      unconsumedPropKeys = getUnconsumedPropKeys(meta);
-    }
-    if (getSkippedPropKeys != null) {
-      skippedPropKeys = getSkippedPropKeys(meta);
-    }
+  if (shouldTestPropForwarding) {
+    final meta = getPropsMeta(factory()(childrenFactory()));
+    if (meta != null) {
+      if (getUnconsumedPropKeys != null) {
+        unconsumedPropKeys = getUnconsumedPropKeys(meta);
+      }
+      if (getSkippedPropKeys != null) {
+        skippedPropKeys = getSkippedPropKeys(meta);
+      }
 
-    _testPropForwarding(
-      factory,
-      childrenFactory,
-      meta: meta,
-      unconsumedPropKeys: unconsumedPropKeys,
-      ignoreDomProps: ignoreDomProps,
-      skippedPropKeys: skippedPropKeys,
-      nonDefaultForwardingTestProps: nonDefaultForwardingTestProps,
-    );
-  } else {
-    if (getUnconsumedPropKeys != null || getSkippedPropKeys != null) {
-      throw ArgumentError(
-          'This component does not correspond to a mixin-based syntax component,'
-          ' and thus cannot be used with the function syntax to specify '
-          'unconsumedPropKeys/skippedPropKeys');
+      _testPropForwarding(
+        factory,
+        childrenFactory,
+        meta: meta,
+        unconsumedPropKeys: unconsumedPropKeys,
+        ignoreDomProps: ignoreDomProps,
+        skippedPropKeys: skippedPropKeys,
+        nonDefaultForwardingTestProps: nonDefaultForwardingTestProps,
+      );
+    } else {
+      if (getUnconsumedPropKeys != null || getSkippedPropKeys != null) {
+        throw ArgumentError(
+            'This component does not correspond to a mixin-based syntax component,'
+            ' and thus cannot be used with the function syntax to specify '
+            'unconsumedPropKeys/skippedPropKeys');
+      }
     }
   }
 

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -76,8 +76,8 @@ import './react_util.dart';
 /// _(which gets flattened into a 1D array of strings)_.
 void commonComponentTests(BuilderOnlyUiFactory factory, {
   bool shouldTestPropForwarding = true,
-  dynamic unconsumedPropKeys = const [],
-  dynamic skippedPropKeys = const [],
+  List unconsumedPropKeys = const [],
+  List skippedPropKeys = const [],
   List Function(PropsMetaCollection) getUnconsumedPropKeys,
   List Function(PropsMetaCollection) getSkippedPropKeys,
   Map nonDefaultForwardingTestProps = const {},

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -1,0 +1,26 @@
+
+import 'package:over_react/over_react.dart';
+import 'package:over_react_test/jacket.dart';
+
+/// Returns the [UiComponent2.propsMeta] obtained by rendering [el].
+///
+/// Returns `null` if [el] does not render a UiComponent2 or does not use the
+/// new mixin syntax (determined by whether accessing propsMeta throws).
+PropsMetaCollection getPropsMeta(ReactElement el) {
+  // Can't auto-tear down here because we're not inside a test.
+  // Use a try-finally instead
+  final jacket = mount(el, autoTearDown: false);
+  try {
+    final instance = jacket.getDartInstance();
+    if (instance is UiComponent2) {
+      try {
+        // ignore: invalid_use_of_protected_member
+        return instance.propsMeta;
+      } catch (_) {}
+    }
+
+    return null;
+  } finally {
+    jacket.unmount();
+  }
+}

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -1,3 +1,16 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/jacket.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   js: ^0.6.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   meta: ^1.1.0
-  over_react: ^3.1.3
+  over_react: ^3.5.0
   react: ^5.2.1
   test: ^1.9.1
 dev_dependencies:
@@ -25,9 +25,3 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
-
-dependency_overrides:
-  over_react:
-    git:
-      url: https://github.com/Workiva/over_react
-      ref: new_boilerplate_part_2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
+  meta: ^1.1.0
   over_react: ^3.1.3
   react: ^5.2.1
   test: ^1.9.1
@@ -24,3 +25,9 @@ transformers:
   - over_react
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
+
+dependency_overrides:
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react
+      ref: new_boilerplate_part_2

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:over_react_test/src/over_react_test/props_meta.dart';
 import 'package:test/test.dart';
 import 'package:over_react_test/over_react_test.dart';
 
 import './utils/test_common_component.dart';
+import './utils/test_common_component_new_boilerplate.dart' as new_boilerplate;
 import './utils/test_common_component_required_props.dart';
 import './utils/test_common_component_required_props_commponent2.dart';
 
@@ -23,10 +25,36 @@ import './utils/test_common_component_required_props_commponent2.dart';
 main() {
   group('commonComponentTests', () {
     // TODO: Improve / expand upon these tests.
-    group('should pass when the correct unconsumed props are specified', () {
+    group('should be a noop and pass when used with a legacy boilerplate component', () {
       commonComponentTests(TestCommon, unconsumedPropKeys: [
         PropsThatShouldBeForwarded.meta.keys,
       ]);
+    });
+
+    group('should pass when the correct unconsumed props are specified', () {
+      commonComponentTests(
+        new_boilerplate.TestCommonForwarding,
+        getUnconsumedPropKeys: (meta) => [
+          ...meta.forMixin(new_boilerplate.ShouldBeForwardedProps).keys,
+        ],
+      );
+    });
+
+    group('should skip checking for certain props', () {
+      final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()());
+      final consumedKeys = meta.forMixin(new_boilerplate.ShouldNotBeForwardedProps).keys;
+      final skippedKey = consumedKeys.first;
+
+      commonComponentTests(
+        () => new_boilerplate.TestCommonForwarding()
+          ..propKeysToForwardAnyways = [skippedKey],
+        getUnconsumedPropKeys: (meta) => [
+          ...meta.forMixin(new_boilerplate.ShouldBeForwardedProps).keys,
+        ],
+        getSkippedPropKeys: (meta) => [
+          skippedKey,
+        ],
+      );
     });
 
     group('should pass when the correct required props are specified', () {

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -1,4 +1,4 @@
-// Copyright 2017 Workiva Inc.
+// Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -1,0 +1,58 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+import 'package:over_react_test/src/over_react_test/wrapper_component.dart';
+
+// ignore: uri_has_not_been_generated
+part 'test_common_component_new_boilerplate.over_react.g.dart';
+
+UiFactory<TestCommonForwardingProps> TestCommonForwarding =
+    _$TestCommonForwarding; // ignore: undefined_identifier
+
+class TestCommonForwardingProps = UiProps
+    with ShouldBeForwardedProps, ShouldNotBeForwardedProps;
+
+class TestCommonForwardingComponent extends UiComponent2<TestCommonForwardingProps> {
+  @override
+  get defaultProps => (newProps()..propKeysToForwardAnyways = []);
+
+  @override
+  get consumedProps => [
+        propsMeta.forMixin(ShouldNotBeForwardedProps),
+      ];
+
+  @override
+  render() {
+    return (Wrapper()
+      ..modifyProps(addUnconsumedProps)
+      ..className = forwardingClassNameBuilder().toClassName()
+      ..modifyProps((p) {
+        for (var key in props.propKeysToForwardAnyways) {
+          p[key] = props[key];
+        }
+      })
+    )(props.children);
+  }
+}
+
+mixin ShouldBeForwardedProps on UiProps {
+  bool foo;
+  bool foo2;
+}
+
+mixin ShouldNotBeForwardedProps on UiProps {
+  bool bar;
+  Iterable propKeysToForwardAnyways;
+}


### PR DESCRIPTION
## Motivation
The new mixin-based boilerplate doesn't support access of prop keys outside of component classes, so we needed to update the `commonComponent` args `unconsumedPropKeys` and `skippedPropKeys`, which currently on accessing static meta variables, to work for new boilerplate components.

Only after updating that did I realize that those args were only used by the commented out unconsumed props test code, which was disabled since there was no path forward after `dart:mirrors` support was dropped.

However, the new boilerplate provides a path forward, since __all__ props classes mixed into a component are available via `propsMeta`! This allows us to reinstate unconsumed props tests for components that use the new mixin-based boilerplate.

## Changes
- Re-instate commonComponentTests for components that use the new boilerplate
- Add `getUnconsumedPropKeys` and `getSkippedPropKeys` that enable consumers to conveniently specify prop keys from `propsMeta`

#### Release Notes
- Re-instate prop forwarding tests for components that use the new mixin-based boilerplate

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @aaronlademann-wf @joebingham-wk @sydneyjodon-wk 
FYI: @corwinsheahan-wf @evanweible-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
