### PR TITLE
RM-72266 Release over_react_test 2.9.1 (HOTFIX)

### DIFF
--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -23,7 +23,7 @@ import 'package:react/react_client/react_interop.dart';
 PropsMetaCollection getPropsMeta(ReactElement el) {
   // ignore: invalid_use_of_protected_member
   final isComponent2 = ReactDartComponentVersion.fromType(el.type) == '2';
-  if (isComponent2) return null;
+  if (!isComponent2) return null;
 
   // Can't auto-tear down here because we're not inside a test.
   // Use a try-finally instead

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -14,12 +14,17 @@
 
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/jacket.dart';
+import 'package:react/react_client/react_interop.dart';
 
 /// Returns the [UiComponent2.propsMeta] obtained by rendering [el].
 ///
 /// Returns `null` if [el] does not render a UiComponent2 or does not use the
 /// new mixin syntax (determined by whether accessing propsMeta throws).
 PropsMetaCollection getPropsMeta(ReactElement el) {
+  // ignore: invalid_use_of_protected_member
+  final isComponent2 = ReactDartComponentVersion.fromType(el.type) == '2';
+  if (isComponent2) return null;
+
   // Can't auto-tear down here because we're not inside a test.
   // Use a try-finally instead
   final jacket = mount(el, autoTearDown: false);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.9.0
+version: 2.9.1
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/


### PR DESCRIPTION
### Problem:

Trying to render a component via `getPropsMeta` directly inside of `commonComponentTests` causes issues when the provided `factory` has required props that come from `setUp`-initialized variables.

For example:
```dart
setUp(() {
  store = MyStore();
});

commonComponentTests(() => factory()..store = store);
```

This is because it's run before the consumer's `setUp` block.

### Solution
Move `getPropsMeta` call to inside `test` block to ensure consumer `setUp` is called first

----

Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/2.9.0...Workiva:release_over_react_test_2.9.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/2.9.0...2.9.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)