### PR TITLE
RM-72368 Release over_react_test 2.9.3 (Hotfix to fix prop type expectations)

### DIFF
--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -525,7 +525,7 @@ final _PropTypeLogMatcher logsNoPropTypeWarnings = _PropTypeLogMatcher(isEmpty);
 /// of running a provided callback, swallowing errors that occur, and looking
 /// for the expected [PropError] in the resulting logs.
 _PropTypeLogMatcher logsPropError(String propName, [String message = '']) {
-  return logsPropTypeWarning('PropError: Prop $propName $message'.trim());
+  return logsPropTypeWarning('PropError: Prop $propName. $message'.trim());
 }
 
 /// A matcher to verify that a [PropError].required is thrown with a provided `propName` and `message`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.9.2
+version: 2.9.3
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -820,7 +820,7 @@ main() {
             ..shouldAlwaysBeFalse = false
             ..shouldLog = false)()),
           logsPropCombinationError(
-              'shoudLog', 'shouldAlwaysBeFalse', 'logging is required'));
+              'shouldLog', 'shouldAlwaysBeFalse', 'logging is required'));
     });
   });
 }

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -49,11 +49,11 @@ class SampleComponent extends UiComponent2<SampleProps> {
           }
 
           if (props.shouldLog == false && props.shouldAlwaysBeFalse == false) {
-            return PropError.combination('shoudLog', 'shouldAlwaysBeFalse', 'logging is required');
+            return PropError.combination('shouldLog', 'shouldAlwaysBeFalse', 'logging is required');
           }
 
           if (props.shouldNeverBeNull == false) {
-            return PropError('shouldNeverBeNull should not be false');
+            return PropError('shouldNeverBeNull', 'should not be false');
           }
 
           return null;


### PR DESCRIPTION
## Motivation
The `logsPropError` matcher that replaces the `throwsPropError` matcher had a typo in the message it expects from the logger.  It is missing a period.

## Changes
1. Add the missing period.
2. Update the tests so that the first and second argument are used - which is the only way the missing period would have caused a test failure.

#### Release Notes
Fix logsPropError matcher message expectation

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @corwinsheahan-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
