### PR TITLE
RM-73871 Release over_react_test 2.9.5 (MSIE 11 Object.values HOTFIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # OverReact Test Changelog
 
+## 2.9.4
+* Normalize the behavior of the `render()` utility function between `UiComponent` and `UiComponent2` components.
+* Un-deprecate the `throwsPropError*` matchers.
+
+## 2.9.3
+* Fix typo in `logsPropError` matcher to ensure consumers can easily migrate from `throwsPropError` when appropriate.
+
+## 2.9.2
+* Move `isComponent2` call inside a `test` block to address consumer issues when the provided factory accesses values that are initialized within `setUp`.  
+
+## 2.9.1
+* Move `getPropsMeta` call inside a `test` block to address consumer issues when the provided factory has required props that come from `setUp`-initialized variables.  
+
+## 2.9.0
+* Add Component Version Auto Detection
+* Re-instate prop forwarding tests for new over_react component boilerplate
+
 ## 2.8.0
 * Update mount, render, and renderAttachedToDocument to automatically run component lifecycle in the same zone as the test.
     * This fixes some `print` statements from being swallowed and some failing `expect`s from not failing tests properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Test Changelog
 
+## 2.9.5
+* Add `Object.values` shim for MSIE 11.
+
 ## 2.9.4
 * Normalize the behavior of the `render()` utility function between `UiComponent` and `UiComponent2` components.
 * Un-deprecate the `throwsPropError*` matchers.

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -652,8 +652,15 @@ List getForwardingTargets(reactInstance, {int expectedTargetCount = 1, shallowRe
           forwardingTargets.add(descendant);
         }
 
+        Iterable<dynamic> propValues;
+        try {
+          propValues = props.values;
+        } catch (_) {
+          // IE 11 doesn't support Object.values
+          propValues = props.keys.map((key) => props[key]);
+        }
         // Most importantly, this includes children, but also includes other props that could contain React content.
-        descendantsToProcess.addAll(props.values);
+        descendantsToProcess.addAll(propValues);
       }
     }
   } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.9.4
+version: 2.9.5
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/


### PR DESCRIPTION
## Motivation
The new prop forwarding test utilities make use of `Object.values`, but MSIE 11 doesn't support it. This causes consumer test failures of the form:

```
NoSuchMethodError: Object doesn't support property or method 'values' (Error 438)

<some_test_file>.dart.js <line>:<col>   L.JsBackedMap.prototype.get$values
<some_test_file>.dart.js <line>:<col>    J.get$values$x
<some_test_file>.dart.js <line>:<col>   P.MapView.prototype.get$values
<some_test_file>.dart.js <line>:<col>  E.getForwardingTargets
<some_test_file>.dart.js <line>:<col>   E._testPropForwarding_closure.prototype.call$0
```

## Changes
Shim the functionality so that consumer tests can run in MSIE 11.

#### Release Notes
Shim `Object.values` for MSIE 11


