### PR TITLE
CPLAT-12003 RM-76349 Release over_react_test 2.9.6 (Fix prop forwarding test false positives)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
   - $HOME/.dart_tool
 
 script:
+  # Must run a build before analyzing as of Dart 2.9.0: See: https://github.com/dart-lang/sdk/issues/42977
+  - pub run build_runner build
   - pub run dart_dev analyze
   - pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers,pedantic
   - pub run dart_dev test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # OverReact Test Changelog
 
+## 2.9.6
+* Fix prop forwarding tests false positives
+  
+  Tests that had `commonComponentTests.getUnconsumedPropKeys()` returning a list of
+  keys that included keys within mixins that were actually being consumed by the component
+  were not failing as expected.
+  
+  e.g. this situation should have resulted in test failures, but it did not:
+  
+  Component's consumedProps:
+  ```dart
+  @override
+  get consumedProps => propsMeta.forMixins({
+    SomePropsMixin,
+  });
+  ```
+  
+  Component's commonComponentTests:
+  ```dart  
+  group('common component tests', () {
+    commonComponentTests(ComponentFactory, getUnconsumedProps: (propsMeta) => [
+      ...propsMeta.forMixin(SomePropsMixin).keys,
+    ]);
+  });
+  ``` 
+
 ## 2.9.5
 * Add `Object.values` shim for MSIE 11.
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,16 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        generate_for:
+          # Only compile the top-level "aggregate" test runner
+          - test/*.browser_test.dart
+        options:
+          # List any dart2js specific args here, or omit it.
+          dart2js_args:
+            # Omit type checks TODO change to -O4 at some point (e.g., --trust-primitives)
+            - -O3
+            # Generate CSP-compliant code since it will be used most often in prod
+            - --csp
+            # Disable minification for dart2js tests
+            - --no-minify

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -267,7 +267,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
       // If the forwarding target is a DOM element it should not have invalid DOM props forwarded to it.
       if (isDomElement(forwardingTarget)) {
         otherProps.forEach((key, value) {
-          expect(actualProps[key], isNot(containsPair(key, value)), reason: unindent('''
+          expect(actualProps, isNot(containsPair(key, value)), reason: unindent('''
             The following mock key/value pair(s) added by this test were found on 
             a DOM component that props were forwarded to:
             

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -305,19 +305,19 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
               @override
               get consumedProps => propsMeta.forMixins({
                 SomeOtherPropsMixin,
-                // leave out ${mixinNamesOfMissingUnconsumedPropKeys.join(', ')}
+                // leave out the mixin(s) containing ${missingUnconsumedPropKeys.join(', ')}
               });
               
               // Option 3: specify the prop mixins that should NOT be consumed:
               @override
               get consumedProps => propsMeta.allExceptForMixins({
-                ${mixinNamesOfMissingUnconsumedPropKeys.join(',\n      ')}
+                // list the mixin(s) containing ${missingUnconsumedPropKeys.join(', ')}
               });
               
           If these props should NOT be forwarded to the forwarding target rendered by this component, 
           remove these lines from the list returned to `commonComponentTests.getUnconsumedPropKeys()`:
           
-              ${mixinNamesOfMissingUnconsumedPropKeys.map((mixin) => 'propsMeta.forMixin($mixin).keys').join(',\n    ')}
+              ${missingUnconsumedPropKeys.map((key) => 'propsMeta.forMixin(/* name of the mixin containing $key */).keys').join(',\n    ')}
         '''));
       }
 

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -117,12 +117,6 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   }
 }
 
-String getPropKeyNamespaceFromPropKey(String propKey) {
-  final indexOfNamespaceSeparator = propKey.indexOf('.');
-  if (indexOfNamespaceSeparator == -1) return null;
-  return propKey.substring(0, indexOfNamespaceSeparator);
-}
-
 Iterable _flatten(Iterable iterable) =>
     iterable.expand((item) => item is Iterable ? _flatten(item) : [item]);
 
@@ -283,8 +277,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
         });
 
         final missingUnconsumedPropKeys = unconsumedProps.keys.where((key) => !actualProps.containsKey(key));
-        final mixinNamesOfMissingUnconsumedPropKeys = missingUnconsumedPropKeys.map(getPropKeyNamespaceFromPropKey).where((name) => name != null).toSet();
-        expect(mixinNamesOfMissingUnconsumedPropKeys, isEmpty, reason: unindent('''
+        expect(missingUnconsumedPropKeys, isEmpty, reason: unindent('''
           UnconsumedProps were not forwarded.
         
           These prop keys were not found within the props of the forwarding target: 
@@ -373,22 +366,19 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
         }
       }
 
-      final propMixinsThatAreUnconsumed = unexpectedKeys.map(getPropKeyNamespaceFromPropKey).toSet().toList();
       expect(unexpectedKeys, isEmpty, reason: unindent('''
             Unexpected keys on forwarding target.
-      
-            One or more props from the following prop mixin(s) were found within the props of 
-            the forwarding target: 
             
-                ${propMixinsThatAreUnconsumed.join(',\n    ')}
+            These prop keys were found within the props of the forwarding target: 
+            
+                ${unexpectedKeys.join(',\n    ')}
             
             But they were not expected to be there since they are not specified
             in the list returned to `commonComponentTests.getUnconsumedPropKeys()` in your test. 
             
             If props from the mixin(s) listed above should be forwarded to the forwarding target rendered 
-            by this component, add these to the list returned to `commonComponentTests.getUnconsumedPropKeys()`: 
-            
-                ${propMixinsThatAreUnconsumed.map((mixin) => 'propsMeta.forMixin($mixin).keys').join(',\n    ')}
+            by this component, add the name of the mixin that contains them to the list returned to 
+            `commonComponentTests.getUnconsumedPropKeys()`
             
             If props from the mixin(s) listed above should NOT be forwarded to the forwarding target rendered 
             by this component, the value of `UiComponent2.consumedProps` must be overridden to include those mixin(s):
@@ -396,7 +386,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
                 // Option 1: specify that the prop mixin(s) should be consumed:
                 @override
                 get consumedProps => propsMeta.forMixins({
-                  ${propMixinsThatAreUnconsumed.map((mixin) => '$mixin').join(',\n      ')}
+                  // Add the names of the mixin(s) in question.
                 });
                 
                 // Option 2: specify the prop mixins that should NOT be consumed:

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -21,6 +21,7 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/component_base.dart' as component_base;
 import 'package:over_react_test/over_react_test.dart';
 import 'package:over_react_test/src/over_react_test/props_meta.dart';
+import 'package:over_react_test/src/over_react_test/test_helpers.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_test_utils.dart' as react_test_utils;
@@ -172,7 +173,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
   @required bool ignoreDomProps,
   @required Map nonDefaultForwardingTestProps,
 }) {
-  test('forwards unconsumed props as expected', () {
+  testFunction('forwards unconsumed props as expected', () {
     // This needs to be retrieved inside a `test`/`setUp`/etc, not inside a group,
     // in case childrenFactory relies on variables set up in the consumer's setUp blocks.
     final meta = getPropsMeta((factory())(childrenFactory()));
@@ -266,7 +267,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
       // If the forwarding target is a DOM element it should not have invalid DOM props forwarded to it.
       if (isDomElement(forwardingTarget)) {
         otherProps.forEach((key, value) {
-          expect(actualProps[key], isNull, reason: unindent('''
+          expect(actualProps[key], isNot(containsPair(key, value)), reason: unindent('''
             The following mock key/value pair(s) added by this test were found on 
             a DOM component that props were forwarded to:
             
@@ -284,6 +285,8 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
         final missingUnconsumedPropKeys = unconsumedProps.keys.where((key) => !actualProps.containsKey(key));
         final mixinNamesOfMissingUnconsumedPropKeys = missingUnconsumedPropKeys.map(getPropKeyNamespaceFromPropKey).where((name) => name != null).toSet();
         expect(mixinNamesOfMissingUnconsumedPropKeys, isEmpty, reason: unindent('''
+          UnconsumedProps were not forwarded.
+        
           These prop keys were not found within the props of the forwarding target: 
             
               ${missingUnconsumedPropKeys.join(',\n    ')}
@@ -372,6 +375,8 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
 
       final propMixinsThatAreUnconsumed = unexpectedKeys.map(getPropKeyNamespaceFromPropKey).toSet().toList();
       expect(unexpectedKeys, isEmpty, reason: unindent('''
+            Unexpected keys on forwarding target.
+      
             One or more props from the following prop mixin(s) were found within the props of 
             the forwarding target: 
             
@@ -424,7 +429,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
 /// > Related: [testClassNameOverrides]
 @isTestGroup
 void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory()) {
-  test('merges classes as expected', () {
+  testFunction('merges classes as expected', () {
     var builder = factory()
       ..addProp(forwardedPropBeacon, true)
       ..className = 'custom-class-1 blacklisted-class-1 custom-class-2 blacklisted-class-2'
@@ -443,7 +448,7 @@ void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory(
     unmount(renderedInstance);
   });
 
-  test('adds custom classes to one and only one element', () {
+  testFunction('adds custom classes to one and only one element', () {
     const customClass = 'custom-class';
 
     var renderedInstance = render(
@@ -451,7 +456,7 @@ void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory(
     );
     var descendantsWithCustomClass = react_test_utils.scryRenderedDOMComponentsWithClass(renderedInstance, customClass);
 
-    expect(descendantsWithCustomClass, hasLength(1));
+    expect(descendantsWithCustomClass, hasLength(1), reason: 'expected a single element with the forwarded custom class');
 
     unmount(renderedInstance);
   });
@@ -491,7 +496,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
     unmount(reactInstanceWithoutOverrides);
   });
 
-  test('can override added class names', () {
+  testFunction('can override added class names', () {
     if (error != null) {
       throw error;
     }
@@ -551,7 +556,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     }
   });
 
-  test('throws (component1) or logs the correct errors (component2) when the required prop is not set or is null', () {
+  testFunction('throws (component1) or logs the correct errors (component2) when the required prop is not set or is null', () {
     void component1RequiredPropsTest(){
       for (var propKey in requiredProps) {
         final reactComponentFactory = factory()
@@ -639,7 +644,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     isComponent2 ? component2RequiredPropsTest() : component1RequiredPropsTest();
   });
 
-  test('nullable props', () {
+  testFunction('nullable props', () {
     if (!isComponent2) {
       for (var propKey in nullableProps) {
         final reactComponentFactory = factory().componentFactory as

--- a/lib/src/over_react_test/test_helpers.dart
+++ b/lib/src/over_react_test/test_helpers.dart
@@ -1,0 +1,7 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+typedef TestFunction = void Function(String, FutureOr Function() callback);
+
+TestFunction testFunction = test;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.9.5
+version: 2.9.6
 description: A library for testing OverReact components
 author: Workiva UI Platform Team <uip@workiva.com>
 homepage: https://github.com/Workiva/over_react_test/

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -43,6 +43,10 @@ main() {
       );
     });
 
+    group('should pass when only dom props are forwarded to a dom element', () {
+      commonComponentTests(new_boilerplate.TestCommonDomOnlyForwarding);
+    });
+
     group('should skip checking for certain props', () {
       final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()());
       final consumedKeys = meta.forMixin(new_boilerplate.ShouldNotBeForwardedProps).keys;

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/src/over_react_test/props_meta.dart';
+import 'package:over_react_test/src/over_react_test/test_helpers.dart';
 import 'package:test/test.dart';
 import 'package:over_react_test/over_react_test.dart';
 
@@ -147,5 +149,165 @@ main() {
         });
       });
     });
+
+    group('fails when a component', () {
+      /// Declares a [group] in which tests declared via [testFunction] are expected to fail
+      /// with an error matching [testFailureMatcher].
+      @isTestGroup
+      void expectedFailGroup(String description, void Function() groupBody, {@required dynamic testFailureMatcher}) {
+        group(description, () {
+          int totalTestCount = 0;
+          List<TestFailure> testFailureErrors;
+          setUpAll(() => testFailureErrors = []);
+
+          void testButReAndIgnoreExceptions(name, testBody) {
+            totalTestCount++;
+            test(name, () async {
+              try {
+                await testBody();
+              } on TestFailure catch (e) {
+                testFailureErrors.add(e);
+              } catch(e, st) {
+                fail('Unexpected test error: $e\n$st');
+              }
+            });
+          }
+
+          ;
+
+          testFunction = testButReAndIgnoreExceptions;
+          groupBody();
+          testFunction = test;
+
+          test('(tests fail check)', () {
+            expect(testFailureErrors, isNotEmpty, reason: 'Expected at least 1 of $totalTestCount tests to fail');
+            expect(
+                testFailureErrors,
+                everyElement(
+                    isA<TestFailure>().having((source) => source.message, 'error message', testFailureMatcher)));
+          });
+        });
+      }
+
+      final testPropsMeta = PropsMetaCollection({
+        DummyProps1: createTestPropsMeta(['Foo.prop1', 'Foo.prop2']),
+        DummyProps2: createTestPropsMeta(['Bar.prop1', 'Bar.prop2']),
+      });
+
+      expectedFailGroup('forwards consumed props -', () {
+        final factory = registerHelperComponent(
+          propsMeta: testPropsMeta,
+          consumedProps: testPropsMeta.all,
+          render: (component) => (Wrapper()..addAll(component.props))(),
+        );
+        commonComponentTests(
+          factory,
+          shouldTestClassNameMerging: false,
+          shouldTestRequiredProps: false,
+          shouldTestClassNameOverrides: false,
+        );
+      }, testFailureMatcher: contains('Unexpected keys on forwarding target'));
+
+      expectedFailGroup('does not forward all of the unconsumed props in propsMeta -', () {
+        var factory = registerHelperComponent(
+          propsMeta: testPropsMeta,
+          consumedProps: [],
+          render: (component) => (Wrapper()
+            ..addAll(component.props)
+            ..remove('Foo.prop1'))(),
+        );
+        commonComponentTests(
+          factory,
+          getUnconsumedPropKeys: (meta) => [
+            ...meta.forMixin(DummyProps1).keys,
+            ...meta.forMixin(DummyProps2).keys,
+          ],
+          shouldTestClassNameMerging: false,
+          shouldTestRequiredProps: false,
+          shouldTestClassNameOverrides: false,
+        );
+      }, testFailureMatcher: contains('UnconsumedProps were not forwarded'));
+    });
   });
+}
+
+abstract class DummyProps1 {}
+
+abstract class DummyProps2 {}
+
+PropsMeta createTestPropsMeta(List<String> keys) => PropsMeta(
+      keys: keys,
+      fields: keys.map((k) => PropDescriptor(k)).toList(),
+    );
+
+typedef HelperRenderFunction = dynamic Function(CommonHelperComponent component);
+
+const UiFactory<UiProps> arbitraryUiFactory = domProps;
+
+UiFactory<UiProps> registerHelperComponent({
+  @required HelperRenderFunction render,
+  Map defaultProps,
+  Iterable<ConsumedProps> consumedProps,
+  PropsMetaCollection propsMeta,
+}) {
+  final factory = registerComponent2(() {
+    return CommonHelperComponent(
+        defaultPropsValue: defaultProps,
+        consumedPropsValue: consumedProps,
+        propsMetaValue: propsMeta,
+        renderValue: render,
+      );
+  });
+
+  return ([Map backingMap]) => arbitraryUiFactory(backingMap)..componentFactory = factory;
+}
+
+class CommonHelperComponent extends UiComponent2<UiProps> {
+  final Map defaultPropsValue;
+  final Iterable<ConsumedProps> consumedPropsValue;
+  final PropsMetaCollection propsMetaValue;
+  final HelperRenderFunction renderValue;
+
+  CommonHelperComponent({
+    @required Map defaultPropsValue,
+    @required Iterable<ConsumedProps> consumedPropsValue,
+    @required PropsMetaCollection propsMetaValue,
+    @required this.renderValue,
+  }) :
+    defaultPropsValue = defaultPropsValue ?? {},
+    propsMetaValue = propsMetaValue ?? const PropsMetaCollection({}),
+    consumedPropsValue = consumedPropsValue ?? propsMetaValue?.all ?? [];
+
+  @override
+  get defaultProps => defaultPropsValue; // ignore: over_react_pseudo_static_lifecycle
+
+  @override
+  get consumedProps => consumedPropsValue;
+
+  @override
+  get propsMeta => propsMetaValue;
+
+  @override
+  render()  => renderValue(this);
+
+  // Implement typically-generated members
+
+  @override
+  bool get $isClassGenerated => false;
+
+  @override
+  typedPropsFactory(map) => arbitraryUiFactory(map);
+
+  @override
+  typedPropsFactoryJs(map) => typedPropsFactory(map);
+
+  UiProps _cachedTypedProps;
+
+  @override
+  UiProps get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    _cachedTypedProps = typedPropsFactory(value);
+  }
 }

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -72,15 +72,15 @@ main() {
         );
       });
 
-    group('when passed a UiComponent2', () {
-      commonComponentTests(() => (TestCommonRequired2()
-            ..bar = true
-            ..foobar = true),
-          shouldTestRequiredProps: true,
-          shouldTestClassNameMerging: false,
-          shouldTestClassNameOverrides: false,
-          shouldTestPropForwarding: false,
-      );
+      group('when passed a UiComponent2', () {
+        commonComponentTests(() => (TestCommonRequired2()
+              ..bar = true
+              ..foobar = true),
+            shouldTestRequiredProps: true,
+            shouldTestClassNameMerging: false,
+            shouldTestClassNameOverrides: false,
+            shouldTestPropForwarding: false,
+        );
       });
     });
 

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -56,3 +56,19 @@ mixin ShouldNotBeForwardedProps on UiProps {
   bool bar;
   Iterable propKeysToForwardAnyways;
 }
+
+UiFactory<TestCommonDomOnlyForwardingProps> TestCommonDomOnlyForwarding =
+    _$TestCommonDomOnlyForwarding; // ignore: undefined_identifier
+
+class TestCommonDomOnlyForwardingProps = UiProps
+    with ShouldBeForwardedProps, ShouldNotBeForwardedProps;
+
+class TestCommonDomOnlyForwardingComponent extends UiComponent2<TestCommonDomOnlyForwardingProps> {
+  @override
+  render() {
+    return (Dom.div()
+      ..modifyProps(addUnconsumedDomProps)
+      ..className = forwardingClassNameBuilder().toClassName()
+    )(props.children);
+  }
+}


### PR DESCRIPTION
This release addresses:

* Fix prop forwarding tests false positives

  Tests that had `commonComponentTests.getUnconsumedPropKeys()` returning a list of
  keys that included keys within mixins that were actually being consumed by the component
  were not failing as expected.

  e.g. this situation should have resulted in test failures, but it did not:

  Component's consumedProps:
  ```dart
  @override
  get consumedProps => propsMeta.forMixins({
    SomePropsMixin,
  });
  ```

  Component's commonComponentTests:
  ```dart  
  group('common component tests', () {
    commonComponentTests(ComponentFactory, getUnconsumedProps: (propsMeta) => [
      ...propsMeta.forMixin(SomePropsMixin).keys,
    ]);
  });
  ``` 