### PR TITLE
CPLAT-11530: Migrate to new over_react boilerplate

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,11 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 
+analyzer:
+  errors:
+    # Ignore ungenerated uri error:
+    # See: https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md#ignore-ungenerated-warnings-project-wide.
+    uri_has_not_been_generated: ignore
+
 linter:
   rules:
     # - always_declare_return_types

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -19,27 +19,31 @@ part 'wrapper_component.over_react.g.dart';
 /// A helper component for use in tests where a component needs to be
 /// rendered inside a wrapper, but a composite component must be used
 /// for compatability with `getByTestId()`.
-@Factory()
 // ignore: undefined_identifier
-UiFactory<UiProps> Wrapper =
+UiFactory<_WrapperProps> Wrapper =
     _$Wrapper; // ignore: undefined_identifier
 
-// TODO: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because it is exported from the following library in this repo:
-// over_react_test/over_react_test.dart/WrapperProps 
-// Upgrading it would be considered a breaking change since consumer components can no longer extend from it. 
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#public-api
-@Props()
-class _$WrapperProps extends UiProps {}
+mixin WrapperPropsMixin on UiProps {}
 
-@Component2()
-class WrapperComponent extends UiComponent2<WrapperProps> {
-  @override
-  render() => (Dom.div()..addAll(props))(props.children);
+@Deprecated(
+    'Use WrapperPropsMixin instead; this class exists solely to support'
+        ' existing components with legacy syntax that extend from it,'
+        ' and will be removed in the next major release')
+abstract class WrapperProps extends UiProps
+    with
+        WrapperPropsMixin,
+    // ignore: mixin_of_non_class, undefined_class
+        $WrapperPropsMixin {
+  @Deprecated(
+      'Convert to new boilerplate and use `propsMeta.forMixins({WrapperPropsMixin})` instead.')
+  // ignore: const_initialized_with_non_constant_value, undefined_class, undefined_identifier
+  static const PropsMeta meta = _$metaForWrapperPropsMixin;
 }
 
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class WrapperProps extends _$WrapperProps with _$WrapperPropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForWrapperProps;
+// ignore: deprecated_member_use_from_same_package
+class _WrapperProps = UiProps with WrapperPropsMixin implements WrapperProps;
+
+class WrapperComponent extends UiComponent2<_WrapperProps> {
+  @override
+  render() => (Dom.div()..addAll(props))(props.children);
 }

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -19,31 +19,11 @@ part 'wrapper_component.over_react.g.dart';
 /// A helper component for use in tests where a component needs to be
 /// rendered inside a wrapper, but a composite component must be used
 /// for compatability with `getByTestId()`.
-// ignore: undefined_identifier
-UiFactory<_WrapperProps> Wrapper =
-    _$Wrapper; // ignore: undefined_identifier
+UiFactory<WrapperProps> Wrapper = _$Wrapper; // ignore: undefined_identifier
 
-mixin WrapperPropsMixin on UiProps {}
+mixin WrapperProps on UiProps {}
 
-@Deprecated(
-    'Use WrapperPropsMixin instead; this class exists solely to support'
-        ' existing components with legacy syntax that extend from it,'
-        ' and will be removed in the next major release')
-abstract class WrapperProps extends UiProps
-    with
-        WrapperPropsMixin,
-    // ignore: mixin_of_non_class, undefined_class
-        $WrapperPropsMixin {
-  @Deprecated(
-      'Convert to new boilerplate and use `propsMeta.forMixins({WrapperPropsMixin})` instead.')
-  // ignore: const_initialized_with_non_constant_value, undefined_class, undefined_identifier
-  static const PropsMeta meta = _$metaForWrapperPropsMixin;
-}
-
-// ignore: deprecated_member_use_from_same_package
-class _WrapperProps = UiProps with WrapperPropsMixin implements WrapperProps;
-
-class WrapperComponent extends UiComponent2<_WrapperProps> {
+class WrapperComponent extends UiComponent2<WrapperProps> {
   @override
   render() => (Dom.div()..addAll(props))(props.children);
 }

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -24,13 +24,15 @@ part 'wrapper_component.over_react.g.dart';
 UiFactory<UiProps> Wrapper =
     _$Wrapper; // ignore: undefined_identifier
 
-// TODO: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because `WrapperComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
+// TODO: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because it is exported from the following library in this repo:
+// over_react_test/over_react_test.dart/WrapperProps 
+// Upgrading it would be considered a breaking change since consumer components can no longer extend from it. 
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#public-api
 @Props()
 class _$WrapperProps extends UiProps {}
 
-@Component()
-class WrapperComponent extends UiComponent<WrapperProps> {
+@Component2()
+class WrapperComponent extends UiComponent2<WrapperProps> {
   @override
   render() => (Dom.div()..addAll(props))(props.children);
 }

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -14,7 +14,6 @@
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'wrapper_component.over_react.g.dart';
 
 /// A helper component for use in tests where a component needs to be
@@ -23,9 +22,11 @@ part 'wrapper_component.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<UiProps> Wrapper =
-    // ignore: undefined_identifier
-    _$Wrapper;
+    
+    _$Wrapper; // ignore: undefined_identifier
 
+// FIXME: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because `WrapperComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$WrapperProps extends UiProps {}
 

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -22,10 +22,9 @@ part 'wrapper_component.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<UiProps> Wrapper =
-    
     _$Wrapper; // ignore: undefined_identifier
 
-// FIXME: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because `WrapperComponent` does not extend from `UiComponent2`.
+// TODO: `WrapperProps` could not be auto-migrated to the new over_react boilerplate because `WrapperComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$WrapperProps extends UiProps {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   matcher: ^0.12.1+4
   meta: ^1.1.0
   over_react: ^3.5.3
+  dart_style: ^1.2.5
   react: ^5.2.1
   test: ^1.9.1
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   matcher: ^0.12.1+4
   meta: ^1.1.0
   over_react: ^3.5.3
-  dart_style: ^1.2.5
   react: ^5.2.1
   test: ^1.9.1
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   meta: ^1.1.0
-  over_react: ^3.5.0
+  over_react: ^3.5.3
   react: ^5.2.1
   test: ^1.9.1
 dev_dependencies:

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -4,9 +4,7 @@ import 'package:over_react/over_react.dart';
 
 part 'sample_component.over_react.g.dart';
 
-// ignore: undefined_identifier
-UiFactory<SampleProps> Sample =
-    _$Sample; // ignore: undefined_identifier
+UiFactory<SampleProps> Sample = _$Sample; // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
   bool shouldNeverBeNull;

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -2,17 +2,14 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'sample_component.over_react.g.dart';
 
-@Factory()
 // ignore: undefined_identifier
 UiFactory<SampleProps> Sample =
-// ignore: undefined_identifier
-    _$Sample;
 
-@Props()
-class _$SampleProps extends UiProps {
+    _$Sample; // ignore: undefined_identifier
+
+mixin SampleProps on UiProps {
   bool shouldNeverBeNull;
 
   bool shouldAlwaysBeFalse;
@@ -30,7 +27,6 @@ class _$SampleProps extends UiProps {
   bool shouldLog;
 }
 
-@Component2()
 class SampleComponent extends UiComponent2<SampleProps> {
   @override
   Map get defaultProps => (newProps()
@@ -108,9 +104,4 @@ class SampleComponent extends UiComponent2<SampleProps> {
   }
 }
 
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class SampleProps extends _$SampleProps with _$SamplePropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForSampleProps;
-}
+

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -6,7 +6,6 @@ part 'sample_component.over_react.g.dart';
 
 // ignore: undefined_identifier
 UiFactory<SampleProps> Sample =
-
     _$Sample; // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
@@ -103,5 +102,3 @@ class SampleComponent extends UiComponent2<SampleProps> {
     if (props.shouldErrorInUnmount) throw Error();
   }
 }
-
-

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -2,17 +2,14 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'sample_component2.over_react.g.dart';
 
-@Factory()
 // ignore: undefined_identifier
 UiFactory<Sample2Props> Sample2 =
-// ignore: undefined_identifier
-    _$Sample2;
 
-@Props()
-class _$Sample2Props extends UiProps {
+    _$Sample2; // ignore: undefined_identifier
+
+mixin Sample2Props on UiProps {
   bool shouldNeverBeNull;
 }
 
@@ -44,9 +41,4 @@ class SampleComponent2 extends UiComponent2<Sample2Props> {
   }
 }
 
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class Sample2Props extends _$Sample2Props with _$Sample2PropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForSample2Props;
-}
+

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -4,9 +4,7 @@ import 'package:over_react/over_react.dart';
 
 part 'sample_component2.over_react.g.dart';
 
-// ignore: undefined_identifier
-UiFactory<Sample2Props> Sample2 =
-    _$Sample2; // ignore: undefined_identifier
+UiFactory<Sample2Props> Sample2 = _$Sample2; // ignore: undefined_identifier
 
 mixin Sample2Props on UiProps {
   bool shouldNeverBeNull;

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -6,14 +6,12 @@ part 'sample_component2.over_react.g.dart';
 
 // ignore: undefined_identifier
 UiFactory<Sample2Props> Sample2 =
-
     _$Sample2; // ignore: undefined_identifier
 
 mixin Sample2Props on UiProps {
   bool shouldNeverBeNull;
 }
 
-@Component2()
 class SampleComponent2 extends UiComponent2<Sample2Props> {
   @override
   get propTypes => {
@@ -40,5 +38,3 @@ class SampleComponent2 extends UiComponent2<Sample2Props> {
     return Dom.div()(props.children);
   }
 }
-
-

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -318,17 +318,16 @@ main() {
 
 // ignore: undefined_identifier
 UiFactory<SampleProps> Sample =
-    
     _$Sample; // ignore: undefined_identifier
 
-// FIXME: `SampleProps` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
+// TODO: `SampleProps` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$SampleProps extends UiProps {
   bool foo;
 }
 
-// FIXME: `SampleState` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
+// TODO: `SampleState` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @State()
 class _$SampleState extends UiState {

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -320,44 +320,23 @@ main() {
 UiFactory<SampleProps> Sample =
     _$Sample; // ignore: undefined_identifier
 
-// TODO: `SampleProps` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
-@Props()
-class _$SampleProps extends UiProps {
+mixin SampleProps on UiProps {
   bool foo;
 }
 
-// TODO: `SampleState` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
-@State()
-class _$SampleState extends UiState {
+mixin SampleState on UiState {
   bool bar;
 }
 
-@Component()
-class SampleComponent extends UiStatefulComponent<SampleProps, SampleState> {
+class SampleComponent extends UiStatefulComponent2<SampleProps, SampleState> {
   @override
-  Map getDefaultProps() => (newProps()..foo = false);
+   get defaultProps => (newProps()..foo = false);
 
   @override
-  Map getInitialState() => (newState()..bar = false);
+   get initialState => (newState()..bar = false);
 
   @override
   render() {
     return Dom.div()();
   }
-}
-
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class SampleProps extends _$SampleProps with _$SamplePropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForSampleProps;
-}
-
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class SampleState extends _$SampleState with _$SampleStateAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = _$metaForSampleState;
 }

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -316,9 +316,7 @@ main() {
   });
 }
 
-// ignore: undefined_identifier
-UiFactory<SampleProps> Sample =
-    _$Sample; // ignore: undefined_identifier
+UiFactory<SampleProps> Sample = _$Sample; // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
   bool foo;

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -20,7 +20,6 @@ import 'package:over_react_test/over_react_test.dart';
 
 import 'helper_components/sample_function_component.dart';
 
-// ignore: uri_has_not_been_generated
 part 'jacket_test.over_react.g.dart';
 
 /// Main entry point for TestJacket testing
@@ -317,17 +316,20 @@ main() {
   });
 }
 
-@Factory()
 // ignore: undefined_identifier
 UiFactory<SampleProps> Sample =
-    // ignore: undefined_identifier
-    _$Sample;
+    
+    _$Sample; // ignore: undefined_identifier
 
+// FIXME: `SampleProps` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$SampleProps extends UiProps {
   bool foo;
 }
 
+// FIXME: `SampleState` could not be auto-migrated to the new over_react boilerplate because `SampleComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @State()
 class _$SampleState extends UiState {
   bool bar;

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1246,10 +1246,9 @@ main() {
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestProps> Test =
-    
     _$Test; // ignore: undefined_identifier
 
-// FIXME: `TestProps` could not be auto-migrated to the new over_react boilerplate because `TestComponent` does not extend from `UiComponent2`.
+// TODO: `TestProps` could not be auto-migrated to the new over_react boilerplate because `TestComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestProps extends UiProps {}
@@ -1268,7 +1267,6 @@ class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
 }
 
 UiFactory<Test2Props> Test2 =
-    
     _$Test2; // ignore: undefined_identifier
 
 mixin Test2Props on UiProps {}

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1248,8 +1248,6 @@ main() {
 UiFactory<TestProps> Test =
     _$Test; // ignore: undefined_identifier
 
-// TODO: `TestProps` could not be auto-migrated to the new over_react boilerplate because `TestComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestProps extends UiProps {}
 

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -23,7 +23,6 @@ import 'package:test/test.dart';
 import 'helper_components/sample_function_component.dart';
 import 'utils/nested_component.dart';
 
-// ignore: uri_has_not_been_generated
 part 'react_util_test.over_react.g.dart';
 
 /// Main entry point for ReactUtil testing
@@ -1247,9 +1246,11 @@ main() {
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestProps> Test =
-    // ignore: undefined_identifier
-    _$Test;
+    
+    _$Test; // ignore: undefined_identifier
 
+// FIXME: `TestProps` could not be auto-migrated to the new over_react boilerplate because `TestComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestProps extends UiProps {}
 
@@ -1267,8 +1268,8 @@ class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
 }
 
 UiFactory<Test2Props> Test2 =
-    // ignore: undefined_identifier
-    _$Test2;
+    
+    _$Test2; // ignore: undefined_identifier
 
 mixin Test2Props on UiProps {}
 

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1244,9 +1244,7 @@ main() {
 }
 
 @Factory()
-// ignore: undefined_identifier
-UiFactory<TestProps> Test =
-    _$Test; // ignore: undefined_identifier
+UiFactory<TestProps> Test = _$Test; // ignore: undefined_identifier
 
 @Props()
 class _$TestProps extends UiProps {}
@@ -1264,8 +1262,7 @@ class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
   static const PropsMeta meta = _$metaForTestProps;
 }
 
-UiFactory<Test2Props> Test2 =
-    _$Test2; // ignore: undefined_identifier
+UiFactory<Test2Props> Test2 = _$Test2; // ignore: undefined_identifier
 
 mixin Test2Props on UiProps {}
 

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -16,32 +16,20 @@ import 'package:over_react/over_react.dart';
 
 part 'nested_component.over_react.g.dart';
 
-@Factory()
 // ignore: undefined_identifier
 UiFactory<NestedProps> Nested =
     _$Nested; // ignore: undefined_identifier
 
-// TODO: `NestedProps` could not be auto-migrated to the new over_react boilerplate because `NestedComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
-@Props()
-class _$NestedProps extends UiProps {}
+mixin NestedProps on UiProps {}
 
-@Component()
-class NestedComponent extends UiComponent<NestedProps> {
+class NestedComponent extends UiComponent2<NestedProps> {
   @override
   render() {
     return (Dom.div()..addTestId('outer'))(
       (Dom.div()
-        ..addProps(copyUnconsumedProps())
+        ..modifyProps(addUnconsumedProps)
         ..addTestId('inner')
       )()
     );
   }
-}
-
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class NestedProps extends _$NestedProps with _$NestedPropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForNestedProps;
 }

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -16,9 +16,7 @@ import 'package:over_react/over_react.dart';
 
 part 'nested_component.over_react.g.dart';
 
-// ignore: undefined_identifier
-UiFactory<NestedProps> Nested =
-    _$Nested; // ignore: undefined_identifier
+UiFactory<NestedProps> Nested = _$Nested; // ignore: undefined_identifier
 
 mixin NestedProps on UiProps {}
 

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -14,15 +14,16 @@
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'nested_component.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<NestedProps> Nested =
-    // ignore: undefined_identifier
-    _$Nested;
+    
+    _$Nested; // ignore: undefined_identifier
 
+// FIXME: `NestedProps` could not be auto-migrated to the new over_react boilerplate because `NestedComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$NestedProps extends UiProps {}
 

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -19,10 +19,9 @@ part 'nested_component.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<NestedProps> Nested =
-    
     _$Nested; // ignore: undefined_identifier
 
-// FIXME: `NestedProps` could not be auto-migrated to the new over_react boilerplate because `NestedComponent` does not extend from `UiComponent2`.
+// TODO: `NestedProps` could not be auto-migrated to the new over_react boilerplate because `NestedComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$NestedProps extends UiProps {}

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -19,7 +19,6 @@ import './test_common_component_nested.dart';
 part 'test_common_component.over_react.g.dart';
 
 @Factory()
-// ignore: undefined_identifier
 UiFactory<TestCommonProps> TestCommon =
     _$TestCommon; // ignore: undefined_identifier
 

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -49,11 +49,27 @@ class TestCommonComponent extends UiComponent<TestCommonProps> {
   }
 }
 
-mixin PropsThatShouldBeForwarded on UiProps {
+@PropsMixin()
+abstract class PropsThatShouldBeForwarded {
+  // To ensure the codemod regression checking works properly, please keep this
+  // field at the top of the class!
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForPropsThatShouldBeForwarded;
+
+  Map get props;
+
   bool foo;
 }
 
-mixin PropsThatShouldNotBeForwarded on UiProps {
+@PropsMixin()
+abstract class PropsThatShouldNotBeForwarded {
+  // To ensure the codemod regression checking works properly, please keep this
+  // field at the top of the class!
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForPropsThatShouldNotBeForwarded;
+
+  Map get props;
+
   bool bar;
 }
 

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -24,7 +24,7 @@ UiFactory<TestCommonProps> TestCommon =
     
     _$TestCommon; // ignore: undefined_identifier
 
-// FIXME: `TestCommonProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonComponent` does not extend from `UiComponent2`.
+// TODO: `TestCommonProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonProps extends UiProps with
@@ -52,19 +52,11 @@ class TestCommonComponent extends UiComponent<TestCommonProps> {
   }
 }
 
- mixin PropsThatShouldBeForwarded on UiProps {
-  
-
-  
-
+mixin PropsThatShouldBeForwarded on UiProps {
   bool foo;
 }
 
- mixin PropsThatShouldNotBeForwarded on UiProps {
-  
-
-  
-
+mixin PropsThatShouldNotBeForwarded on UiProps {
   bool bar;
 }
 

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -16,15 +16,16 @@ import 'package:over_react/over_react.dart';
 
 import './test_common_component_nested.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonProps> TestCommon =
-    // ignore: undefined_identifier
-    _$TestCommon;
+    
+    _$TestCommon; // ignore: undefined_identifier
 
+// FIXME: `TestCommonProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonProps extends UiProps with
     PropsThatShouldBeForwarded,
@@ -51,26 +52,18 @@ class TestCommonComponent extends UiComponent<TestCommonProps> {
   }
 }
 
-@PropsMixin()
-abstract class PropsThatShouldBeForwarded {
-  // To ensure the codemod regression checking works properly, please keep this
-  // field at the top of the class!
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForPropsThatShouldBeForwarded;
+ mixin PropsThatShouldBeForwarded on UiProps {
+  
 
-  Map get props;
+  
 
   bool foo;
 }
 
-@PropsMixin()
-abstract class PropsThatShouldNotBeForwarded {
-  // To ensure the codemod regression checking works properly, please keep this
-  // field at the top of the class!
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForPropsThatShouldNotBeForwarded;
+ mixin PropsThatShouldNotBeForwarded on UiProps {
+  
 
-  Map get props;
+  
 
   bool bar;
 }

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -21,11 +21,8 @@ part 'test_common_component.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonProps> TestCommon =
-    
     _$TestCommon; // ignore: undefined_identifier
 
-// TODO: `TestCommonProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonProps extends UiProps with
     PropsThatShouldBeForwarded,

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -17,15 +17,16 @@ import 'package:over_react/over_react.dart';
 import './test_common_component.dart';
 import './test_common_component_nested2.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component_nested.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonNestedProps> TestCommonNested =
-    // ignore: undefined_identifier
-    _$TestCommonNested;
+    
+    _$TestCommonNested; // ignore: undefined_identifier
 
+// FIXME: `TestCommonNestedProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonNestedComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}
 

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -24,8 +24,6 @@ part 'test_common_component_nested.over_react.g.dart';
 UiFactory<TestCommonNestedProps> TestCommonNested =
     _$TestCommonNested; // ignore: undefined_identifier
 
-// TODO: `TestCommonNestedProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonNestedComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}
 

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -20,7 +20,6 @@ import './test_common_component_nested2.dart';
 part 'test_common_component_nested.over_react.g.dart';
 
 @Factory()
-// ignore: undefined_identifier
 UiFactory<TestCommonNestedProps> TestCommonNested =
     _$TestCommonNested; // ignore: undefined_identifier
 

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -22,10 +22,9 @@ part 'test_common_component_nested.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonNestedProps> TestCommonNested =
-    
     _$TestCommonNested; // ignore: undefined_identifier
 
-// FIXME: `TestCommonNestedProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonNestedComponent` does not extend from `UiComponent2`.
+// TODO: `TestCommonNestedProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonNestedComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNestedProps extends UiProps with PropsThatShouldBeForwarded {}

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -19,10 +19,9 @@ part 'test_common_component_nested2.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonNested2Props> TestCommonNested2 =
-    
     _$TestCommonNested2; // ignore: undefined_identifier
 
-// FIXME: `TestCommonNested2Props` could not be auto-migrated to the new over_react boilerplate because `TestCommonNested2Component` does not extend from `UiComponent2`.
+// TODO: `TestCommonNested2Props` could not be auto-migrated to the new over_react boilerplate because `TestCommonNested2Component` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNested2Props extends UiProps {}

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -17,7 +17,6 @@ import 'package:over_react/over_react.dart';
 part 'test_common_component_nested2.over_react.g.dart';
 
 @Factory()
-// ignore: undefined_identifier
 UiFactory<TestCommonNested2Props> TestCommonNested2 =
     _$TestCommonNested2; // ignore: undefined_identifier
 

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -14,15 +14,16 @@
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component_nested2.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonNested2Props> TestCommonNested2 =
-    // ignore: undefined_identifier
-    _$TestCommonNested2;
+    
+    _$TestCommonNested2; // ignore: undefined_identifier
 
+// FIXME: `TestCommonNested2Props` could not be auto-migrated to the new over_react boilerplate because `TestCommonNested2Component` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNested2Props extends UiProps {}
 

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -21,8 +21,6 @@ part 'test_common_component_nested2.over_react.g.dart';
 UiFactory<TestCommonNested2Props> TestCommonNested2 =
     _$TestCommonNested2; // ignore: undefined_identifier
 
-// TODO: `TestCommonNested2Props` could not be auto-migrated to the new over_react boilerplate because `TestCommonNested2Component` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonNested2Props extends UiProps {}
 

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -15,7 +15,6 @@
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/src/over_react_test/wrapper_component.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component_new_boilerplate.over_react.g.dart';
 
 UiFactory<TestCommonForwardingProps> TestCommonForwarding =

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -14,15 +14,16 @@
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component_required_props.over_react.g.dart';
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonRequiredProps> TestCommonRequired =
-    // ignore: undefined_identifier
-    _$TestCommonRequired;
+    
+    _$TestCommonRequired; // ignore: undefined_identifier
 
+// FIXME: `TestCommonRequiredProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonRequiredComponent` does not extend from `UiComponent2`.
+// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonRequiredProps extends UiProps {
   @nullableRequiredProp

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -21,8 +21,6 @@ part 'test_common_component_required_props.over_react.g.dart';
 UiFactory<TestCommonRequiredProps> TestCommonRequired =
     _$TestCommonRequired; // ignore: undefined_identifier
 
-// TODO: `TestCommonRequiredProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonRequiredComponent` does not extend from `UiComponent2`.
-// For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonRequiredProps extends UiProps {
   @nullableRequiredProp

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -17,7 +17,6 @@ import 'package:over_react/over_react.dart';
 part 'test_common_component_required_props.over_react.g.dart';
 
 @Factory()
-// ignore: undefined_identifier
 UiFactory<TestCommonRequiredProps> TestCommonRequired =
     _$TestCommonRequired; // ignore: undefined_identifier
 

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -19,10 +19,9 @@ part 'test_common_component_required_props.over_react.g.dart';
 @Factory()
 // ignore: undefined_identifier
 UiFactory<TestCommonRequiredProps> TestCommonRequired =
-    
     _$TestCommonRequired; // ignore: undefined_identifier
 
-// FIXME: `TestCommonRequiredProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonRequiredComponent` does not extend from `UiComponent2`.
+// TODO: `TestCommonRequiredProps` could not be auto-migrated to the new over_react boilerplate because `TestCommonRequiredComponent` does not extend from `UiComponent2`.
 // For instructions on how to proceed, see: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#non-component2
 @Props()
 class _$TestCommonRequiredProps extends UiProps {

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -17,7 +17,6 @@ import 'package:over_react/over_react.dart';
 part 'test_common_component_required_props_commponent2.over_react.g.dart';
 
 UiFactory<TestCommonRequiredProps2> TestCommonRequired2 =
-    
     _$TestCommonRequired2; // ignore: undefined_identifier
 
 mixin TestCommonRequiredProps2 on UiProps {

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -30,7 +30,6 @@ mixin TestCommonRequired2Props on UiProps {
   bool defaultFoo;
 }
 
-@Component2()
 class TestCommonRequired2Component extends
     UiComponent2<TestCommonRequired2Props> {
   @override

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -14,16 +14,13 @@
 
 import 'package:over_react/over_react.dart';
 
-// ignore: uri_has_not_been_generated
 part 'test_common_component_required_props_commponent2.over_react.g.dart';
 
-@Factory()
 UiFactory<TestCommonRequiredProps2> TestCommonRequired2 =
-    // ignore: undefined_identifier
-    _$TestCommonRequired2;
+    
+    _$TestCommonRequired2; // ignore: undefined_identifier
 
-@Props()
-class _$TestCommonRequiredProps2 extends UiProps {
+mixin TestCommonRequiredProps2 on UiProps {
   @nullableRequiredProp
   bool foobar;
 
@@ -38,8 +35,8 @@ class _$TestCommonRequiredProps2 extends UiProps {
 class TestCommonRequiredComponent2 extends
     UiComponent2<TestCommonRequiredProps2> {
   @override
-  get consumedProps => const [
-    TestCommonRequiredProps2.meta,
+  get consumedProps =>  [
+    propsMeta.forMixin(TestCommonRequiredProps2),
   ];
 
   @override
@@ -54,9 +51,4 @@ class TestCommonRequiredComponent2 extends
   }
 }
 
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class TestCommonRequiredProps2 extends _$TestCommonRequiredProps2 with _$TestCommonRequiredProps2AccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForTestCommonRequiredProps2;
-}
+

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -16,10 +16,10 @@ import 'package:over_react/over_react.dart';
 
 part 'test_common_component_required_props_commponent2.over_react.g.dart';
 
-UiFactory<TestCommonRequiredProps2> TestCommonRequired2 =
+UiFactory<TestCommonRequired2Props> TestCommonRequired2 =
     _$TestCommonRequired2; // ignore: undefined_identifier
 
-mixin TestCommonRequiredProps2 on UiProps {
+mixin TestCommonRequired2Props on UiProps {
   @nullableRequiredProp
   bool foobar;
 
@@ -31,11 +31,11 @@ mixin TestCommonRequiredProps2 on UiProps {
 }
 
 @Component2()
-class TestCommonRequiredComponent2 extends
-    UiComponent2<TestCommonRequiredProps2> {
+class TestCommonRequired2Component extends
+    UiComponent2<TestCommonRequired2Props> {
   @override
   get consumedProps =>  [
-    propsMeta.forMixin(TestCommonRequiredProps2),
+    propsMeta.forMixin(TestCommonRequired2Props),
   ];
 
   @override


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review, merge and release.

## Motivation
While converting the boilerplate for OverReact component declaration from Dart 1 transformers to Dart 2 builders, we encountered several constraints that made us choose between dropping backwards compatibility _(mainly support for props class inheritance)_, and a less-than-optimal boilerplate.

To make the Dart 2 transition as smooth as possible, we chose to keep the new boilerplate version as backwards-compatible as possible, while compromising the cleanliness of the boilerplate. In time, we found that this wasn't great from a user experience or from a tooling perspective.

Knowing this, and having dropped support for Dart 1, we have implemented an improved version of OverReact boilerplate that fixes issues introduced in the "transitional" version, as well as other miscellaneous ones.

> __For more details, check out the [New OverReact Boilerplate Guide](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md).__

To summarize the new boilerplate changes:

- Props/state classes are now always declared as mixins, and can't `extend` from other props classes anymore (but you can still mix them in)!)
- No more stubbed-in concrete props classes at the end of the file
- Annotations (`Factory()`, `@Props()`, etc.) are omitted unless they have arguments
- `consumedProps` includes props from all used props mixins by default
- uri_has_not_been_generated errors are ignored by default (via workiva_analysis_options)
- "Go to reference" in IDEs for props now takes you to the source and not the generated code 
- Multiple components per file are allowed (the old boilerplate also gets this, as a bonus!)

Basically...
```diff
-// ignore: uri_has_not_been_generated
 part 'foo.over_react.g.dart';

-@Factory()
 UiFactory<FooProps> Foo =
-    // ignore: undefined_identifier
-    _$Foo;
+    _$Foo; // ignore: undefined_identifier

-@Props()
-class _$FooProps extends UiProps {
+mixin FooProps on UiProps {
   String foo;
 }

-@Component2()
 class FooComponent extends UiComponent2<FooProps> {
   @override
   render() => 'foo: ${props.foo}';
 }
-
-// ignore: mixin_of_non_class, undefined_class
-class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
-  // ignore: undefined_identifier, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForFooProps;
-}
```


## Changes
**_(These might be a bit easier to read with split diff)_**

1. Bump the lower bound of the over_react dependency to pull in the 
  builder changes necessary to support the boilerplate changes. 
1. Migrate all _compatible_ component declarations to the new boilerplate.
    - Components that have not yet been [migrated to `UiComponent2`](https://github.com/Workiva/over_react/blob/master/doc/ui_component2_transition.md) cannot use the new boilerplate.
    - Components that have publicly exported props or state classes cannot be migrated without causing breaking changes. 
1. Add `TODO` comments to any part of a declaration that could not be migrated automatically.

## Review
__Please review, QA and merge:__ <tag repo owners / contributors here>

### QA Checklist
- [ ] Passing CI
- [ ] Verify/smokecheck that Components upgraded to the new boilerplate are still functioning as expected.

#### Release Notes
- Migrate compatible component declarations to the new OverReact boilerplate.

> [More information about the new OverReact component boilerplate](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md)
