### PR TITLE
Update OverReact syntax to support Dart 2.9+

### DIFF
--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -19,7 +19,7 @@ part 'wrapper_component.over_react.g.dart';
 /// A helper component for use in tests where a component needs to be
 /// rendered inside a wrapper, but a composite component must be used
 /// for compatability with `getByTestId()`.
-UiFactory<WrapperProps> Wrapper = _$Wrapper; // ignore: undefined_identifier
+UiFactory<WrapperProps> Wrapper = castUiFactory(_$Wrapper); // ignore: undefined_identifier
 
 mixin WrapperProps on UiProps {}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
   meta: ^1.1.0
-  over_react: ">=3.5.3 <5.0.0"
+  over_react: ^4.1.0
   react: ">=5.5.1 <7.0.0"
   test: ^1.9.1
 dev_dependencies:

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -4,7 +4,7 @@ import 'package:over_react/over_react.dart';
 
 part 'sample_component.over_react.g.dart';
 
-UiFactory<SampleProps> Sample = _$Sample; // ignore: undefined_identifier
+UiFactory<SampleProps> Sample = castUiFactory(_$Sample); // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
   bool shouldNeverBeNull;

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -4,7 +4,7 @@ import 'package:over_react/over_react.dart';
 
 part 'sample_component2.over_react.g.dart';
 
-UiFactory<Sample2Props> Sample2 = _$Sample2; // ignore: undefined_identifier
+UiFactory<Sample2Props> Sample2 = castUiFactory(_$Sample2); // ignore: undefined_identifier
 
 mixin Sample2Props on UiProps {
   bool shouldNeverBeNull;

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -316,7 +316,7 @@ main() {
   });
 }
 
-UiFactory<SampleProps> Sample = _$Sample; // ignore: undefined_identifier
+UiFactory<SampleProps> Sample = castUiFactory(_$Sample); // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
   bool foo;

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1262,7 +1262,7 @@ class TestProps extends _$TestProps with _$TestPropsAccessorsMixin {
   static const PropsMeta meta = _$metaForTestProps;
 }
 
-UiFactory<Test2Props> Test2 = _$Test2; // ignore: undefined_identifier
+UiFactory<Test2Props> Test2 = castUiFactory(_$Test2); // ignore: undefined_identifier
 
 mixin Test2Props on UiProps {}
 

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -16,7 +16,7 @@ import 'package:over_react/over_react.dart';
 
 part 'nested_component.over_react.g.dart';
 
-UiFactory<NestedProps> Nested = _$Nested; // ignore: undefined_identifier
+UiFactory<NestedProps> Nested = castUiFactory(_$Nested); // ignore: undefined_identifier
 
 mixin NestedProps on UiProps {}
 

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -18,7 +18,7 @@ import 'package:over_react_test/src/over_react_test/wrapper_component.dart';
 part 'test_common_component_new_boilerplate.over_react.g.dart';
 
 UiFactory<TestCommonForwardingProps> TestCommonForwarding =
-    _$TestCommonForwarding; // ignore: undefined_identifier
+    castUiFactory(_$TestCommonForwarding); // ignore: undefined_identifier
 
 class TestCommonForwardingProps = UiProps
     with ShouldBeForwardedProps, ShouldNotBeForwardedProps;
@@ -57,7 +57,7 @@ mixin ShouldNotBeForwardedProps on UiProps {
 }
 
 UiFactory<TestCommonDomOnlyForwardingProps> TestCommonDomOnlyForwarding =
-    _$TestCommonDomOnlyForwarding; // ignore: undefined_identifier
+    castUiFactory(_$TestCommonDomOnlyForwarding); // ignore: undefined_identifier
 
 class TestCommonDomOnlyForwardingProps = UiProps
     with ShouldBeForwardedProps, ShouldNotBeForwardedProps;

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -17,7 +17,7 @@ import 'package:over_react/over_react.dart';
 part 'test_common_component_required_props_commponent2.over_react.g.dart';
 
 UiFactory<TestCommonRequired2Props> TestCommonRequired2 =
-    _$TestCommonRequired2; // ignore: undefined_identifier
+    castUiFactory(_$TestCommonRequired2); // ignore: undefined_identifier
 
 mixin TestCommonRequired2Props on UiProps {
   @nullableRequiredProp


### PR DESCRIPTION
## Motivation
In order to enable Workiva to transition to Dart >=2.9.0 with ease, a slight update to OverReact factory syntax
is required.

__Important:__
1. Remember to update your snippets in order to prevent accidental regressions in boilerplate. [Here](https://github.com/Workiva/over_react/blob/master/snippets/README.md)
is the reference for OverReact snippets.
1. To prevent incompatible boilerplate from being introduced, a react-boilerplate core-check has been activated. This
core check will fail if the incompatible mixin based boilerplate is introduced again to a project that has migrated already.

> For more information on why this migration is important, see [this wiki update](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=182026853).

__NOTE:__ Only the mixin based boilerplate factories will be migrated. In other words, if your factory is still
using the `@Factory` annotation, it will not be migrated to the Dart 2.9-compatible boilerplate and must first
be [migrated to the mixin based syntax](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md#upgrading-existing-code).
For additional reference, [here](https://github.com/Workiva/web_skin_dart/blob/master/doc/Component2-Migration-Guide.md)
are the instructions to migrate for projects depedent on Web Skin Dart.

## Changes
Below are two examples of the minor tweaks that will occur. For a reference of all the small changes that will occur
(including to the `connect` syntax), refer to option #2 [here](https://jsfiddle.net/greglittlefieldwf/onemhutb/show).
Note that `ignore` comments are not included in those examples.

1. Switch factory declarations to use the new syntax.
    ```diff
    UiFactory<FooProps> Foo = 
    -    _$Foo; // ignore: undefined_identifier, invalid_assignment
    +   castUiFactory(_$Foo); // ignore: undefined_identifier
    ```
1. For functional components, use the private config instead of the public one.
    ```diff
    UiFactory<FooProps> Foo = uiFunction(
      (props) {
        return 'Foo';
      },
    -  $FooConfig, // ignore: undefined_identifier
    +  _$FooConfig, // ignore: undefined_identifier
    );
    ```
1. Bump minimum over_react version to be compatible with the new syntax.

## Release Notes
Migrate mixin based factories to the Dart 2.9-compatible boilerplate.

## QA
These changes are not expected to require any special form of QA. As long as CI performs analysis on Dart code and runs a Dart build,
a passing CI is sufficient to merge these changes.

For more information or questions, reach out to us in the #support-ui-platform Slack channel.


[_Created by Sourcegraph campaign `Workiva/dart2_9_boilerplate_migration`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/dart2_9_boilerplate_migration)