### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/test/over_react_test.dart
+++ b/test/over_react_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 
 import 'package:over_react_test/over_react_test.dart';

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)