### PR TITLE
Consumer testing for https://github.com/Workiva/over_react/pull/698

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,11 @@ homepage: https://github.com/Workiva/over_react_test/
 environment:
   sdk: '>=2.7.0 <3.0.0'
 
+dependency_overrides:
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: conditionallly-unconvert-style-children
 dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4


### PR DESCRIPTION
Consume https://github.com/Workiva/over_react/pull/698

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5124665064816640/logs/)