### PR TITLE
Vanilla Dart images Need Updateing

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, dev ]
+        sdk: [ 2.7.2, 2.13.4, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable ]
+        sdk: [ 2.7.2, 2.13.4, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable ]
+        sdk: [ 2.7.2, 2.13.4, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.7 as dart2
+FROM google/dart:2.13 as dart2
 # Build Environment Vars
 ARG BUILD_ID
 ARG BUILD_NUMBER

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.5.1
+  build_web_compilers: ^2.9.0
   dependency_validator: ^1.4.0
   pedantic: ^1.8.0


### PR DESCRIPTION
## Motivation/ Changes
As a part of the Dart 2.13 transition, FROM google/dart:2.7 needs to be changed over to FROM google/dart:2.13.

### QA Checklist
- [ ] CI passes

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
