### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pub get --no-precompile
 
       - name: Validate dependencies
-        run: pub run dependency_validator -i coverage,build_runner,build_test,build_web_compilers,meta,pedantic
+        run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
       - name: Analyze project source

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.9.0
-  dependency_validator: ^1.4.0
+  dependency_validator: ^2.0.0
   pedantic: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,3 +18,7 @@ dev_dependencies:
   build_web_compilers: ^2.9.0
   dependency_validator: ^2.0.0
   pedantic: ^1.8.0
+
+dependency_validator:
+  ignore:
+    - meta # until we can remove the pin on meta


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)