### PR TITLE
Consumer testing for https://github.com/Workiva/over_react/pull/720

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,11 @@ homepage: https://github.com/Workiva/over_react_test/
 environment:
   sdk: ">=2.11.0 <3.0.0"
 
+dependency_overrides:
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: auto-teardown-adapter-stores
 dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4


### PR DESCRIPTION
Consume https://github.com/Workiva/over_react/pull/720

Pull Requests included in release:
* Patch changes:
	* [Fix analyzer plugin build in Dart stable](https://github.com/Workiva/over_react/pull/696)
	* [Consume react-dart 6.1.3](https://github.com/Workiva/over_react/pull/714)
	* [Consume react-dart 6.1.4](https://github.com/Workiva/over_react/pull/715)
	* [Upgrade dependency_validator](https://github.com/Workiva/over_react/pull/716)
	* [Disable CI on Dart >=2.14 for now](https://github.com/Workiva/over_react/pull/717)
	* [Update test_html_builder to v2](https://github.com/Workiva/over_react/pull/718)
	* [Remove dart2_constant](https://github.com/Workiva/over_react/pull/719)

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5124665064816640/logs/)