### PR TITLE
Narrow dependency_validator range to avoid NNBD issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: '>=2.12.0 <4.0.0'
-  dependency_validator: '>=2.0.0 <4.0.0'
+  dependency_validator: ^2.0.0
   pedantic: ^1.8.0
 
 dependency_validator:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,10 @@ dependencies:
   react: ^6.0.1
   test: ^1.15.7
 dev_dependencies:
-  build_runner: '>=1.7.1 <3.0.0'
-  build_test: ">=0.10.9 <3.0.0"
-  build_web_compilers: '>=2.12.0 <4.0.0'
-  dependency_validator: ^2.0.0
+  build_runner: ^2.1.2
+  build_test: ^2.1.3
+  build_web_compilers: ^3.0.0
+  dependency_validator: ^3.2.2
   pedantic: ^1.8.0
 
 dependency_validator:


### PR DESCRIPTION
We recently discovered that if a package resolves to `dependency_validator >=3.0.0`
and `build_config <1.0.0`, running the `dependency_validator` tool will fail
during precompilation due to null safety.

We are merging a fix to `dependency_validator`, but unfortunately it won't
prevent consumers from resolving to the v3.x versions that still have the
issue. This PR addresses the issue for consumers by narrowing the range to
no longer include `dependency_validator v3`.

Note: We originally widened this range as a part of the effort to upgrade
our ecosystem to `analyzer v1`, but it is not strictly necessary. Consumers
of `dependency_validator v2` can still successfully resolve to `analyzer v1`.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/narrow_dependency_validator_range`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/narrow_dependency_validator_range)