### PR TITLE
RM-163394 Release over_react_test 2.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # OverReact Test Changelog
 
+## 2.11.5
+* Unpin meta dependency
+
+## 2.11.4
+* Internal updates (dev_dependencies, CI)
+
+## 2.11.3
+* Internal updates (dev_dependencies, cleanup)
+
+## 2.11.2
+* Set minimum Dart SDK to 2.11.0
+
 ## 2.11.1
 
 * [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/over_react_test/pull/117)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 2.11.4
+version: 2.11.5
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Raise analyzer minimum & unpin meta](https://github.com/Workiva/over_react_test/pull/140)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/2.11.4...Workiva:release_over_react_test_2.11.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/2.11.4...2.11.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4871683861643264/?repo_name=Workiva%2Fover_react_test&pull_number=141)