### PR TITLE
WIP: Null safety 

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, 2.18.7, stable, dev ]
+        sdk: [ 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, 2.18.7, stable ]
+        sdk: [ 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, 2.18.7, stable ]
+        sdk: [ 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -71,14 +71,6 @@ jobs:
           name: ddc-test-results@${{ matrix.sdk }}
           path: reports/${{ matrix.sdk }}/ddc/test-results.json
 
-      - name: Report Unit Test Results
-        uses: dorny/test-reporter@v1
-        if: ${{ always() && steps.install.outcome == 'success' }}
-        with:
-          name: Unit Test Results (ddc - ${{ matrix.sdk }})
-          path: 'reports/${{ matrix.sdk }}/ddc/test-results.json'
-          reporter: dart-json
-
   test_dart2js:
     permissions:
       id-token: write
@@ -112,11 +104,3 @@ jobs:
         with:
           name: dart2js-test-results@${{ matrix.sdk }}
           path: reports/${{ matrix.sdk }}/dart2js/test-results.json
-
-      - name: Report Unit Test Results
-        uses: dorny/test-reporter@v1
-        if: ${{ always() && steps.install.outcome == 'success' }}
-        with:
-          name: Unit Test Results (dart2js - ${{ matrix.sdk }})
-          path: 'reports/${{ matrix.sdk }}/dart2js/test-results.json'
-          reporter: dart-json

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, dev ]
+        sdk: [ 2.13.4, 2.18.7, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable ]
+        sdk: [ 2.13.4, 2.18.7, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable ]
+        sdk: [ 2.13.4, 2.18.7, stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/lib/jacket.dart
+++ b/lib/jacket.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2018 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/jacket.dart
+++ b/lib/jacket.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2018 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/over_react_test.dart
+++ b/lib/over_react_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/over_react_test.dart
+++ b/lib/over_react_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -81,16 +81,16 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   bool shouldTestPropForwarding = true,
   List unconsumedPropKeys = const [],
   List skippedPropKeys = const [],
-  List Function(PropsMetaCollection) getUnconsumedPropKeys,
-  List Function(PropsMetaCollection) getSkippedPropKeys,
+  List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
+  List Function(PropsMetaCollection)/*?*/ getSkippedPropKeys,
   Map nonDefaultForwardingTestProps = const {},
   bool shouldTestClassNameMerging = true,
   bool shouldTestClassNameOverrides = true,
   bool ignoreDomProps = true,
   bool shouldTestRequiredProps = true,
   @Deprecated('This flag is not needed as the test will auto detect the version')
-  bool isComponent2,
-  dynamic childrenFactory()
+  bool/*?*/ isComponent2,
+  dynamic childrenFactory()/*?*/
 }) {
   childrenFactory ??= _defaultChildrenFactory;
 
@@ -135,11 +135,11 @@ void expectCleanTestSurfaceAtEnd() {
   Set<Element> nodesBefore;
 
   setUpAll(() {
-    nodesBefore = document.body.children.toSet();
+    nodesBefore = document.body/*!*/.children.toSet();
   });
 
   tearDownAll(() {
-    Set<Element> nodesAfter = document.body.children.toSet();
+    Set<Element> nodesAfter = document.body/*!*/.children.toSet();
     var nodesAdded = nodesAfter.difference(nodesBefore).map((element) => element.outerHtml).toList();
 
     expect(nodesAdded, isEmpty, reason: 'tests should leave the test surface clean.');
@@ -163,8 +163,8 @@ void expectCleanTestSurfaceAtEnd() {
 void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory(), {
   @required List unconsumedPropKeys,
   @required List skippedPropKeys,
-  @required List Function(PropsMetaCollection) getUnconsumedPropKeys,
-  @required List Function(PropsMetaCollection) getSkippedPropKeys,
+  @required List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
+  @required List Function(PropsMetaCollection)/*?*/ getSkippedPropKeys,
   @required bool ignoreDomProps,
   @required Map nonDefaultForwardingTestProps,
 }) {
@@ -335,7 +335,7 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
       /// Test for prop keys that both are forwarded and exist on the forwarding target's default props.
       if (isDartComponent(forwardingTarget)) {
         final forwardingTargetType = (forwardingTarget as ReactElement).type as ReactClass;
-        Map forwardingTargetDefaults;
+        Map/*?*/ forwardingTargetDefaults;
         switch (forwardingTargetType.dartComponentVersion) { // ignore: invalid_use_of_protected_member
           case ReactDartComponentVersion.component: // ignore: invalid_use_of_protected_member
             forwardingTargetDefaults = forwardingTargetType.dartDefaultProps; // ignore: deprecated_member_use
@@ -427,7 +427,7 @@ void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory(
       ..classNameBlacklist = 'blacklisted-class-1 blacklisted-class-2';
 
     var renderedInstance = render(builder(childrenFactory()));
-    Iterable<Element> forwardingTargetNodes = getForwardingTargets(renderedInstance).map(findDomNode);
+    Iterable<Element/*?*/> forwardingTargetNodes = getForwardingTargets(renderedInstance).map(findDomNode);
 
     expect(forwardingTargetNodes, everyElement(
         allOf(
@@ -477,7 +477,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
     // but still fail the test if something goes wrong.
     try {
       classesToOverride = getForwardingTargets(reactInstanceWithoutOverrides)
-          .map((target) => findDomNode(target).classes)
+          .map((target) => findDomNode(target)/*!*/.classes)
           .expand((CssClassSet classSet) => classSet)
           .toSet();
     } catch(e) {
@@ -500,7 +500,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
         )(childrenFactory())
     );
 
-    Iterable<Element> forwardingTargetNodes = getForwardingTargets(reactInstance).map(findDomNode);
+    Iterable<Element/*?*/> forwardingTargetNodes = getForwardingTargets(reactInstance).map(findDomNode);
     expect(forwardingTargetNodes, everyElement(
         hasExactClasses('')
     ), reason: '$classesToOverride not overridden');
@@ -580,8 +580,8 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     void component2RequiredPropsTest() {
       PropTypes.resetWarningCache();
 
-      List<String> consoleErrors = [];
-      JsFunction originalConsoleError = context['console']['error'];
+      List<String/*?*/> consoleErrors = [];
+      JsFunction/*?*/ originalConsoleError = context['console']['error'];
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
@@ -590,10 +590,10 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
       });
 
       final reactComponentFactory = factory().componentFactory as
-      ReactDartComponentFactoryProxy2; // ignore: avoid_as
+      ReactDartComponentFactoryProxy2/*?*//*!*//*!*/; // ignore: avoid_as
 
       for (var propKey in requiredProps) {
-        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+        if (!reactComponentFactory/*!*/.defaultProps.containsKey(propKey)) {
 
           try {
             mount((factory()
@@ -657,12 +657,12 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     } else {
       PropTypes.resetWarningCache();
 
-      List<String> consoleErrors = [];
-      JsFunction originalConsoleError = context['console']['error'];
+      List<String/*!*/> consoleErrors = [];
+      JsFunction/*?*//*?*/ originalConsoleError = context['console']['error'];
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
-        originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
+        originalConsoleError/*!*/.apply([message, arg1, arg2, arg3,  arg4, arg5],
             thisArg: self);
       });
 
@@ -671,7 +671,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
 
       for (var propKey in nullableProps) {
         // Props that are defined in the default props map will never not be set.
-        if (!reactComponentFactory.defaultProps.containsKey(propKey)) {
+        if (!reactComponentFactory/*!*/.defaultProps.containsKey(propKey)) {
           try {
             mount((factory()
               ..remove(propKey)

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -542,7 +543,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
           requiredProps.add(prop.key);
         }
 
-        keyToErrorMessage[prop.key] = prop.errorMessage ?? '';
+        keyToErrorMessage[prop.key] = prop.errorMessage;
       }
     }
   });

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -81,16 +81,16 @@ void commonComponentTests(BuilderOnlyUiFactory factory, {
   bool shouldTestPropForwarding = true,
   List unconsumedPropKeys = const [],
   List skippedPropKeys = const [],
-  List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
-  List Function(PropsMetaCollection)/*?*/ getSkippedPropKeys,
+  List Function(PropsMetaCollection)? getUnconsumedPropKeys,
+  List Function(PropsMetaCollection)? getSkippedPropKeys,
   Map nonDefaultForwardingTestProps = const {},
   bool shouldTestClassNameMerging = true,
   bool shouldTestClassNameOverrides = true,
   bool ignoreDomProps = true,
   bool shouldTestRequiredProps = true,
   @Deprecated('This flag is not needed as the test will auto detect the version')
-  bool/*?*/ isComponent2,
-  dynamic childrenFactory()/*?*/
+  bool? isComponent2,
+  dynamic childrenFactory()?
 }) {
   childrenFactory ??= _defaultChildrenFactory;
 
@@ -132,14 +132,14 @@ Iterable _flatten(Iterable iterable) =>
 ///       });
 ///     }
 void expectCleanTestSurfaceAtEnd() {
-  Set<Element> nodesBefore;
+  late Set<Element> nodesBefore;
 
   setUpAll(() {
-    nodesBefore = document.body/*!*/.children.toSet();
+    nodesBefore = document.body!.children.toSet();
   });
 
   tearDownAll(() {
-    Set<Element> nodesAfter = document.body/*!*/.children.toSet();
+    Set<Element> nodesAfter = document.body!.children.toSet();
     var nodesAdded = nodesAfter.difference(nodesBefore).map((element) => element.outerHtml).toList();
 
     expect(nodesAdded, isEmpty, reason: 'tests should leave the test surface clean.');
@@ -161,12 +161,12 @@ void expectCleanTestSurfaceAtEnd() {
 /// todo make this public again if there's a need to expose it, once the API has stabilized
 @isTest
 void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory(), {
-  @required List unconsumedPropKeys,
-  @required List skippedPropKeys,
-  @required List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
-  @required List Function(PropsMetaCollection)/*?*/ getSkippedPropKeys,
-  @required bool ignoreDomProps,
-  @required Map nonDefaultForwardingTestProps,
+  required List unconsumedPropKeys,
+  required List skippedPropKeys,
+  required List Function(PropsMetaCollection)? getUnconsumedPropKeys,
+  required List Function(PropsMetaCollection)? getSkippedPropKeys,
+  required bool ignoreDomProps,
+  required Map nonDefaultForwardingTestProps,
 }) {
   testFunction('forwards unconsumed props as expected', () {
     // This needs to be retrieved inside a `test`/`setUp`/etc, not inside a group,
@@ -335,18 +335,18 @@ void _testPropForwarding(BuilderOnlyUiFactory factory, dynamic childrenFactory()
       /// Test for prop keys that both are forwarded and exist on the forwarding target's default props.
       if (isDartComponent(forwardingTarget)) {
         final forwardingTargetType = (forwardingTarget as ReactElement).type as ReactClass;
-        Map/*?*/ forwardingTargetDefaults;
+        Map? forwardingTargetDefaults;
         switch (forwardingTargetType.dartComponentVersion) { // ignore: invalid_use_of_protected_member
           case ReactDartComponentVersion.component: // ignore: invalid_use_of_protected_member
             forwardingTargetDefaults = forwardingTargetType.dartDefaultProps; // ignore: deprecated_member_use
             break;
           case ReactDartComponentVersion.component2: // ignore: invalid_use_of_protected_member
-            forwardingTargetDefaults = JsBackedMap.backedBy(forwardingTargetType.defaultProps);
+            forwardingTargetDefaults = JsBackedMap.backedBy(forwardingTargetType.defaultProps!);
             break;
         }
 
         var commonForwardedAndDefaults = propKeysThatShouldNotGetForwarded
-            .intersection(forwardingTargetDefaults.keys.toSet());
+            .intersection(forwardingTargetDefaults!.keys.toSet());
 
         /// Don't count these as unexpected keys in later assertions; we'll verify them within this block.
         unexpectedKeys.removeAll(commonForwardedAndDefaults);
@@ -427,7 +427,7 @@ void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory(
       ..classNameBlacklist = 'blacklisted-class-1 blacklisted-class-2';
 
     var renderedInstance = render(builder(childrenFactory()));
-    Iterable<Element/*?*/> forwardingTargetNodes = getForwardingTargets(renderedInstance).map(findDomNode);
+    Iterable<Element?> forwardingTargetNodes = getForwardingTargets(renderedInstance).map(findDomNode);
 
     expect(forwardingTargetNodes, everyElement(
         allOf(
@@ -461,7 +461,7 @@ void testClassNameMerging(BuilderOnlyUiFactory factory, dynamic childrenFactory(
 /// > Related: [testClassNameMerging]
 @isTestGroup
 void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactory()) {
-  Set<String> classesToOverride;
+  late Set<String> classesToOverride;
   var error;
 
   setUp(() {
@@ -477,7 +477,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
     // but still fail the test if something goes wrong.
     try {
       classesToOverride = getForwardingTargets(reactInstanceWithoutOverrides)
-          .map((target) => findDomNode(target)/*!*/.classes)
+          .map((target) => findDomNode(target)!.classes)
           .expand((CssClassSet classSet) => classSet)
           .toSet();
     } catch(e) {
@@ -500,7 +500,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
         )(childrenFactory())
     );
 
-    Iterable<Element/*?*/> forwardingTargetNodes = getForwardingTargets(reactInstance).map(findDomNode);
+    Iterable<Element?> forwardingTargetNodes = getForwardingTargets(reactInstance).map(findDomNode);
     expect(forwardingTargetNodes, everyElement(
         hasExactClasses('')
     ), reason: '$classesToOverride not overridden');
@@ -514,7 +514,7 @@ void testClassNameOverrides(BuilderOnlyUiFactory factory, dynamic childrenFactor
 /// __Note__: All required props must be provided by [factory].
 @isTestGroup
 void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) {
-  bool isComponent2;
+  late bool isComponent2;
 
   var keyToErrorMessage = {};
   var nullableProps = <String>[];
@@ -531,7 +531,7 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     isComponent2 = version == ReactDartComponentVersion.component2;
 
     var jacket = mount(factory()(childrenFactory()), autoTearDown: false);
-    var consumedProps = (jacket.getDartInstance() as component_base.UiComponent).consumedProps;
+    var consumedProps = (jacket.getDartInstance() as component_base.UiComponent).consumedProps!;
     jacket.unmount();
 
     for (var consumedProp in consumedProps) {
@@ -580,20 +580,20 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     void component2RequiredPropsTest() {
       PropTypes.resetWarningCache();
 
-      List<String/*?*/> consoleErrors = [];
-      JsFunction/*?*/ originalConsoleError = context['console']['error'];
+      List<String?> consoleErrors = [];
+      JsFunction? originalConsoleError = context['console']['error'];
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
-        originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
+        originalConsoleError!.apply([message, arg1, arg2, arg3,  arg4, arg5],
             thisArg: self);
       });
 
       final reactComponentFactory = factory().componentFactory as
-      ReactDartComponentFactoryProxy2/*?*//*!*//*!*/; // ignore: avoid_as
+      ReactDartComponentFactoryProxy2?/*!*//*!*/; // ignore: avoid_as
 
       for (var propKey in requiredProps) {
-        if (!reactComponentFactory/*!*/.defaultProps.containsKey(propKey)) {
+        if (!reactComponentFactory!.defaultProps.containsKey(propKey)) {
 
           try {
             mount((factory()
@@ -657,21 +657,21 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
     } else {
       PropTypes.resetWarningCache();
 
-      List<String/*!*/> consoleErrors = [];
-      JsFunction/*?*//*?*/ originalConsoleError = context['console']['error'];
+      List<String> consoleErrors = [];
+      JsFunction?/*?*/ originalConsoleError = context['console']['error'];
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
         consoleErrors.add(message);
-        originalConsoleError/*!*/.apply([message, arg1, arg2, arg3,  arg4, arg5],
+        originalConsoleError!.apply([message, arg1, arg2, arg3,  arg4, arg5],
             thisArg: self);
       });
 
       final reactComponentFactory = factory().componentFactory as
-          ReactDartComponentFactoryProxy2; // ignore: avoid_as
+          ReactDartComponentFactoryProxy2?; // ignore: avoid_as
 
       for (var propKey in nullableProps) {
         // Props that are defined in the default props map will never not be set.
-        if (!reactComponentFactory/*!*/.defaultProps.containsKey(propKey)) {
+        if (!reactComponentFactory!.defaultProps.containsKey(propKey)) {
           try {
             mount((factory()
               ..remove(propKey)

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -34,16 +34,16 @@ import 'package:react/react_client/react_interop.dart';
 /// props that are not valid, the errors will be caught to allow the test to complete.
 ///
 /// To handle asynchronous behavior, see [recordConsoleLogsAsync].
-List<String/*?*/> recordConsoleLogs(
+List<String?> recordConsoleLogs(
   Function() callback, {
   ConsoleConfiguration configuration = allConfig,
   bool shouldResetPropTypesWarningCache = true,
 }) {
-  final consoleLogs = <String/*?*/>[];
+  final consoleLogs = <String?>[];
   final logTypeToCapture = configuration.logType == 'all'
       ? ConsoleConfiguration.types
       : [configuration.logType];
-  Map<String, JsFunction/*?*/> consoleRefs = {};
+  Map<String, JsFunction?> consoleRefs = {};
 
   if (shouldResetPropTypesWarningCache) _resetPropTypeWarningCache();
 
@@ -54,7 +54,7 @@ List<String/*?*/> recordConsoleLogs(
       // NOTE: Using console.log or print within this function will cause an infinite
       // loop when the logType is set to `log`.
       consoleLogs.add(message);
-      consoleRefs[config]
+      consoleRefs[config]!
           .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
     });
   }
@@ -81,16 +81,16 @@ List<String/*?*/> recordConsoleLogs(
 /// with the exception being the provided callback should be asynchronous.
 ///
 /// Related: [recordConsoleLogs]
-FutureOr<List<String/*?*/>> recordConsoleLogsAsync(
+FutureOr<List<String?>> recordConsoleLogsAsync(
   Future Function() asyncCallback, {
   ConsoleConfiguration configuration = allConfig,
   bool shouldResetPropTypesWarningCache = true,
 }) async {
-  var consoleLogs = <String/*?*/>[];
+  var consoleLogs = <String?>[];
   final logTypeToCapture = configuration.logType == 'all'
       ? ConsoleConfiguration.types
       : [configuration.logType];
-  Map<String, JsFunction/*?*/> consoleRefs = {};
+  Map<String, JsFunction?> consoleRefs = {};
 
   if (shouldResetPropTypesWarningCache) _resetPropTypeWarningCache();
 
@@ -101,7 +101,7 @@ FutureOr<List<String/*?*/>> recordConsoleLogsAsync(
       // NOTE: Using console.log or print within this function will cause an infinite
       // loop when the logType is set to `log`.
       consoleLogs.add(message);
-      consoleRefs[config]/*!*/
+      consoleRefs[config]!
           .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
     });
   }

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -34,16 +34,16 @@ import 'package:react/react_client/react_interop.dart';
 /// props that are not valid, the errors will be caught to allow the test to complete.
 ///
 /// To handle asynchronous behavior, see [recordConsoleLogsAsync].
-List<String> recordConsoleLogs(
+List<String/*?*/> recordConsoleLogs(
   Function() callback, {
   ConsoleConfiguration configuration = allConfig,
   bool shouldResetPropTypesWarningCache = true,
 }) {
-  final consoleLogs = <String>[];
+  final consoleLogs = <String/*?*/>[];
   final logTypeToCapture = configuration.logType == 'all'
       ? ConsoleConfiguration.types
       : [configuration.logType];
-  Map<String, JsFunction> consoleRefs = {};
+  Map<String, JsFunction/*?*/> consoleRefs = {};
 
   if (shouldResetPropTypesWarningCache) _resetPropTypeWarningCache();
 
@@ -81,16 +81,16 @@ List<String> recordConsoleLogs(
 /// with the exception being the provided callback should be asynchronous.
 ///
 /// Related: [recordConsoleLogs]
-FutureOr<List<String>> recordConsoleLogsAsync(
+FutureOr<List<String/*?*/>> recordConsoleLogsAsync(
   Future Function() asyncCallback, {
   ConsoleConfiguration configuration = allConfig,
   bool shouldResetPropTypesWarningCache = true,
 }) async {
-  var consoleLogs = <String>[];
+  var consoleLogs = <String/*?*/>[];
   final logTypeToCapture = configuration.logType == 'all'
       ? ConsoleConfiguration.types
       : [configuration.logType];
-  Map<String, JsFunction> consoleRefs = {};
+  Map<String, JsFunction/*?*/> consoleRefs = {};
 
   if (shouldResetPropTypesWarningCache) _resetPropTypeWarningCache();
 
@@ -101,7 +101,7 @@ FutureOr<List<String>> recordConsoleLogsAsync(
       // NOTE: Using console.log or print within this function will cause an infinite
       // loop when the logType is set to `log`.
       consoleLogs.add(message);
-      consoleRefs[config]
+      consoleRefs[config]/*!*/
           .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
     });
   }

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -61,7 +61,7 @@ class ClassNameMatcher extends Matcher {
     // There's a bug in DDC where, though the docs say `className` should
     // return `String`, it will return `AnimatedString` for `SvgElement`s. See
     // https://github.com/dart-lang/sdk/issues/36200.
-    String castClassName;
+    /*late*/String castClassName;
     if (className is String) {
       castClassName = className;
     } else if (className is AnimatedString) {
@@ -114,16 +114,16 @@ class ClassNameMatcher extends Matcher {
   @override
   Description describeMismatch(item, Description mismatchDescription, Map matchState, bool verbose) {
     Set missingClasses = matchState['missingClasses'];
-    Set unwantedClasses = matchState['unwantedClasses'];
-    List extraneousClasses = matchState['extraneousClasses'];
+    Set/*!*/ unwantedClasses = matchState['unwantedClasses'];
+    List/*!*/ extraneousClasses = matchState['extraneousClasses'];
 
     List<String> descriptionParts = [];
     if (allowExtraneous) {
-      if (unwantedClasses.isNotEmpty) {
+      if (unwantedClasses/*!*/.isNotEmpty) {
         descriptionParts.add('has unwanted classes: $unwantedClasses');
       }
     } else {
-      if (extraneousClasses.isNotEmpty) {
+      if (extraneousClasses/*!*/.isNotEmpty) {
         descriptionParts.add('has extraneous classes: $extraneousClasses');
       }
     }
@@ -164,7 +164,7 @@ class _HasToStringValue extends CustomMatcher {
   _HasToStringValue(matcher) : super('Object with toString() value', 'toString()', matcher);
 
   @override
-  featureValueOf(Object item) => item.toString();
+  featureValueOf(Object/*?*/ item) => item.toString();
 }
 
 class _HasPropMatcher extends CustomMatcher {
@@ -187,7 +187,7 @@ class _HasPropMatcher extends CustomMatcher {
 
   @override
   Map featureValueOf(item) {
-    if (_useDomAttributes(item)) return findDomNode(item).attributes;
+    if (_useDomAttributes(item)) return findDomNode(item)/*!*/.attributes;
     if (item is react.Component) return item.props;
 
     return getProps(item);
@@ -269,7 +269,7 @@ class _IsFocused extends Matcher {
         ..add('is not a valid Element.');
     }
 
-    if (!document.documentElement.contains(item)) {
+    if (!document.documentElement/*!*/.contains(item)) {
       return mismatchDescription
         ..add('is not attached to the document, and thus cannot be focused.')
         ..add(' If testing with React, you can use `renderAttachedToDocument`.');
@@ -314,7 +314,7 @@ Matcher throwsPropError(String propName, [String message = '']) {
 ///
 /// __Note__: The [message] is matched rather than the [Error] instance due to Dart's wrapping of all `throw`
 ///  as a [DomException]
-Matcher throwsPropError_Required(String propName, [String message = '']) {
+Matcher throwsPropError_Required(String propName, [String/*?*/ message = '']) {
   return throwsA(anyOf(
       hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
       hasToStringValue(contains('RequiredPropError: Prop $propName is required. $message'.trim()))
@@ -362,10 +362,10 @@ Matcher throwsPropError_Combination(String propName, String prop2Name, [String m
 /// and pass it to [recordConsoleLogs] to run the function and record the resulting
 /// logs that are emitted during the function runtime.
 class _LoggingFunctionMatcher extends CustomMatcher {
-  _LoggingFunctionMatcher(dynamic matcher, {this.config, String description, String name, bool onlyIfAssertsAreEnabled = false})
+  _LoggingFunctionMatcher(dynamic matcher, {this.config, String/*?*/ description, String/*?*/ name, bool onlyIfAssertsAreEnabled = false})
       : super(description ?? 'emits the logs', name ?? 'logs', _wrapMatcherForSingleLog(matcher, onlyIfAssertsAreEnabled));
 
-  final ConsoleConfiguration config;
+  final ConsoleConfiguration/*?*/ config;
 
   static dynamic _wrapMatcherForSingleLog(dynamic expected, [bool onlyIfAssertsAreEnabled = false]) {
     if (onlyIfAssertsAreEnabled && !assertsEnabled()) return anything;
@@ -400,7 +400,7 @@ class _LoggingFunctionMatcher extends CustomMatcher {
 /// caught error.
 ///
 /// Related: [logsToConsole], [hasNoLogs]
-Matcher hasLog(dynamic expected, {ConsoleConfiguration consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
+Matcher hasLog(dynamic expected, {ConsoleConfiguration/*?*/ consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
     _LoggingFunctionMatcher(anyElement(contains(expected)), config: consoleConfig, onlyIfAssertsAreEnabled: onlyIfAssertsAreEnabled);
 
 /// A Matcher used to compare a list of logs against a provided matcher.
@@ -440,7 +440,7 @@ Matcher hasLog(dynamic expected, {ConsoleConfiguration consoleConfig, bool onlyI
 /// ```
 ///
 /// Related: [hasLog], [hasNoLogs]
-Matcher logsToConsole(dynamic expected, {ConsoleConfiguration consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
+Matcher logsToConsole(dynamic expected, {ConsoleConfiguration/*?*/ consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
     _LoggingFunctionMatcher(expected, config: consoleConfig, onlyIfAssertsAreEnabled: onlyIfAssertsAreEnabled);
 
 /// A matcher to verify that a callback function does not emit any logs.

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -120,11 +121,11 @@ class ClassNameMatcher extends Matcher {
 
     List<String> descriptionParts = [];
     if (allowExtraneous) {
-      if (unwantedClasses!.isNotEmpty) {
+      if (unwantedClasses.isNotEmpty) {
         descriptionParts.add('has unwanted classes: $unwantedClasses');
       }
     } else {
-      if (extraneousClasses!.isNotEmpty) {
+      if (extraneousClasses.isNotEmpty) {
         descriptionParts.add('has extraneous classes: $extraneousClasses');
       }
     }

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/custom_matchers.dart
+++ b/lib/src/over_react_test/custom_matchers.dart
@@ -15,6 +15,7 @@
 import 'dart:html';
 import 'dart:svg';
 
+import 'package:collection/collection.dart' show IterableNullableExtension;
 import 'package:over_react/over_react.dart';
 import 'package:matcher/matcher.dart';
 import 'package:over_react_test/src/over_react_test/dart_util.dart';
@@ -46,7 +47,7 @@ class ClassNameMatcher extends Matcher {
   static Iterable getClassIterable(dynamic classNames) {
     Iterable classes;
     if (classNames is Iterable<String>) {
-      classes = classNames.where((className) => className != null).expand(splitSpaceDelimitedString);
+      classes = classNames.whereNotNull().expand(splitSpaceDelimitedString);
     } else if (classNames is String) {
       classes = splitSpaceDelimitedString(classNames);
     } else {
@@ -61,7 +62,7 @@ class ClassNameMatcher extends Matcher {
     // There's a bug in DDC where, though the docs say `className` should
     // return `String`, it will return `AnimatedString` for `SvgElement`s. See
     // https://github.com/dart-lang/sdk/issues/36200.
-    /*late*/String castClassName;
+    late String? castClassName;
     if (className is String) {
       castClassName = className;
     } else if (className is AnimatedString) {
@@ -114,16 +115,16 @@ class ClassNameMatcher extends Matcher {
   @override
   Description describeMismatch(item, Description mismatchDescription, Map matchState, bool verbose) {
     Set missingClasses = matchState['missingClasses'];
-    Set/*!*/ unwantedClasses = matchState['unwantedClasses'];
-    List/*!*/ extraneousClasses = matchState['extraneousClasses'];
+    Set unwantedClasses = matchState['unwantedClasses'];
+    List extraneousClasses = matchState['extraneousClasses'];
 
     List<String> descriptionParts = [];
     if (allowExtraneous) {
-      if (unwantedClasses/*!*/.isNotEmpty) {
+      if (unwantedClasses!.isNotEmpty) {
         descriptionParts.add('has unwanted classes: $unwantedClasses');
       }
     } else {
-      if (extraneousClasses/*!*/.isNotEmpty) {
+      if (extraneousClasses!.isNotEmpty) {
         descriptionParts.add('has extraneous classes: $extraneousClasses');
       }
     }
@@ -164,7 +165,7 @@ class _HasToStringValue extends CustomMatcher {
   _HasToStringValue(matcher) : super('Object with toString() value', 'toString()', matcher);
 
   @override
-  featureValueOf(Object/*?*/ item) => item.toString();
+  featureValueOf(Object? item) => item.toString();
 }
 
 class _HasPropMatcher extends CustomMatcher {
@@ -187,7 +188,7 @@ class _HasPropMatcher extends CustomMatcher {
 
   @override
   Map featureValueOf(item) {
-    if (_useDomAttributes(item)) return findDomNode(item)/*!*/.attributes;
+    if (_useDomAttributes(item)) return findDomNode(item)!.attributes;
     if (item is react.Component) return item.props;
 
     return getProps(item);
@@ -269,7 +270,7 @@ class _IsFocused extends Matcher {
         ..add('is not a valid Element.');
     }
 
-    if (!document.documentElement/*!*/.contains(item)) {
+    if (!document.documentElement!.contains(item)) {
       return mismatchDescription
         ..add('is not attached to the document, and thus cannot be focused.')
         ..add(' If testing with React, you can use `renderAttachedToDocument`.');
@@ -314,7 +315,7 @@ Matcher throwsPropError(String propName, [String message = '']) {
 ///
 /// __Note__: The [message] is matched rather than the [Error] instance due to Dart's wrapping of all `throw`
 ///  as a [DomException]
-Matcher throwsPropError_Required(String propName, [String/*?*/ message = '']) {
+Matcher throwsPropError_Required(String propName, [String? message = '']) {
   return throwsA(anyOf(
       hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
       hasToStringValue(contains('RequiredPropError: Prop $propName is required. $message'.trim()))
@@ -362,10 +363,10 @@ Matcher throwsPropError_Combination(String propName, String prop2Name, [String m
 /// and pass it to [recordConsoleLogs] to run the function and record the resulting
 /// logs that are emitted during the function runtime.
 class _LoggingFunctionMatcher extends CustomMatcher {
-  _LoggingFunctionMatcher(dynamic matcher, {this.config, String/*?*/ description, String/*?*/ name, bool onlyIfAssertsAreEnabled = false})
+  _LoggingFunctionMatcher(dynamic matcher, {this.config, String? description, String? name, bool onlyIfAssertsAreEnabled = false})
       : super(description ?? 'emits the logs', name ?? 'logs', _wrapMatcherForSingleLog(matcher, onlyIfAssertsAreEnabled));
 
-  final ConsoleConfiguration/*?*/ config;
+  final ConsoleConfiguration? config;
 
   static dynamic _wrapMatcherForSingleLog(dynamic expected, [bool onlyIfAssertsAreEnabled = false]) {
     if (onlyIfAssertsAreEnabled && !assertsEnabled()) return anything;
@@ -375,7 +376,7 @@ class _LoggingFunctionMatcher extends CustomMatcher {
 
   @override
   featureValueOf(actual) {
-    var logs = <String>[];
+    List<String?> logs = <String>[];
 
     if (actual is List) return actual;
 
@@ -400,7 +401,7 @@ class _LoggingFunctionMatcher extends CustomMatcher {
 /// caught error.
 ///
 /// Related: [logsToConsole], [hasNoLogs]
-Matcher hasLog(dynamic expected, {ConsoleConfiguration/*?*/ consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
+Matcher hasLog(dynamic expected, {ConsoleConfiguration? consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
     _LoggingFunctionMatcher(anyElement(contains(expected)), config: consoleConfig, onlyIfAssertsAreEnabled: onlyIfAssertsAreEnabled);
 
 /// A Matcher used to compare a list of logs against a provided matcher.
@@ -440,7 +441,7 @@ Matcher hasLog(dynamic expected, {ConsoleConfiguration/*?*/ consoleConfig, bool 
 /// ```
 ///
 /// Related: [hasLog], [hasNoLogs]
-Matcher logsToConsole(dynamic expected, {ConsoleConfiguration/*?*/ consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
+Matcher logsToConsole(dynamic expected, {ConsoleConfiguration? consoleConfig, bool onlyIfAssertsAreEnabled = false}) =>
     _LoggingFunctionMatcher(expected, config: consoleConfig, onlyIfAssertsAreEnabled: onlyIfAssertsAreEnabled);
 
 /// A matcher to verify that a callback function does not emit any logs.

--- a/lib/src/over_react_test/dart_util.dart
+++ b/lib/src/over_react_test/dart_util.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 /// Returns whether `assert`s are enabled in the current runtime.
 ///
 /// Unless the Dart SDK option to enable `assert`s in dart2js is configured,

--- a/lib/src/over_react_test/dart_util.dart
+++ b/lib/src/over_react_test/dart_util.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 /// Returns whether `assert`s are enabled in the current runtime.
 ///
 /// Unless the Dart SDK option to enable `assert`s in dart2js is configured,

--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -61,7 +61,7 @@ void triggerDocumentClick(Element target) {
 ///
 /// Verifies that the [target] element is not a detached node.
 void triggerDocumentMouseEvent(Element target, String event) {
-  if (!document.documentElement/*!*/.contains(target)) {
+  if (!document.documentElement!.contains(target)) {
     throw ArgumentError.value(target, 'target', 'Target should be attached to the document.');
   }
 
@@ -76,7 +76,7 @@ void triggerDocumentMouseEvent(Element target, String event) {
 ///
 /// See: <https://connect.microsoft.com/IE/feedback/details/2238257/ie11-focus-change-delayed-when-using-the-focus-method>.
 Future triggerFocus(Element target, {Duration timeout = _defaultTriggerTimeout}) {
-  if (!document.documentElement/*!*/.contains(target)) {
+  if (!document.documentElement!.contains(target)) {
     throw ArgumentError.value(target, 'target', 'Target should be attached to the document.');
   }
 

--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/dom_util.dart
+++ b/lib/src/over_react_test/dom_util.dart
@@ -61,7 +61,7 @@ void triggerDocumentClick(Element target) {
 ///
 /// Verifies that the [target] element is not a detached node.
 void triggerDocumentMouseEvent(Element target, String event) {
-  if (!document.documentElement.contains(target)) {
+  if (!document.documentElement/*!*/.contains(target)) {
     throw ArgumentError.value(target, 'target', 'Target should be attached to the document.');
   }
 
@@ -76,7 +76,7 @@ void triggerDocumentMouseEvent(Element target, String event) {
 ///
 /// See: <https://connect.microsoft.com/IE/feedback/details/2238257/ie11-focus-change-delayed-when-using-the-focus-method>.
 Future triggerFocus(Element target, {Duration timeout = _defaultTriggerTimeout}) {
-  if (!document.documentElement.contains(target)) {
+  if (!document.documentElement/*!*/.contains(target)) {
     throw ArgumentError.value(target, 'target', 'Target should be attached to the document.');
   }
 

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -46,7 +46,7 @@ import './zone_util.dart';
 ///
 /// To have the instance not automatically unmounted when the test if over set [autoTearDown] to `false`.
 TestJacket<T> mount<T extends react.Component>(over_react.ReactElement reactElement, {
-    Element/*?*/ mountNode,
+    Element? mountNode,
     bool attachedToDocument = false,
     bool autoTearDown = true
 }) {
@@ -58,16 +58,16 @@ TestJacket<T> mount<T extends react.Component>(over_react.ReactElement reactElem
 }
 
 /// Provides more a more consistent and easier to use API to test and manipulate a rendered [ReactComponent].
-class TestJacket<T extends react.Component/*?*/> {
+class TestJacket<T extends react.Component?> {
 
-  TestJacket._(over_react.ReactElement reactElement, {Element/*?*/ mountNode, this.attachedToDocument = false, this.autoTearDown = true})
+  TestJacket._(over_react.ReactElement reactElement, {Element? mountNode, this.attachedToDocument = false, this.autoTearDown = true})
       : mountNode = mountNode ?? (DivElement()
     ..style.height = '800px'
     ..style.width = '800px') {
     _render(reactElement);
   }
 
-  /* [1] */ Object/*?*/ _renderedInstance;
+  /* [1] */ Object? _renderedInstance;
   final Element mountNode;
   final bool attachedToDocument;
   final bool autoTearDown;
@@ -115,7 +115,7 @@ class TestJacket<T extends react.Component/*?*/> {
   /// >   ```
   /// >   queryByTestId(jacket.mountNode, yourTestId)
   /// >   ```
-  ReactComponent/*?*/ getInstance() {
+  ReactComponent? getInstance() {
     // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
     //     a DOM component (Element) - does not throw. The cast to `ReactComponent` - while not "sound", is harmless
     //     since it is an anonymous JS interop class - not a Dart type.
@@ -137,7 +137,7 @@ class TestJacket<T extends react.Component/*?*/> {
       '''));
     }
 
-    return _renderedInstance as ReactComponent/*?*/;
+    return _renderedInstance as ReactComponent?;
   }
 
   /// Returns the props associated with the mounted React composite component instance.
@@ -169,7 +169,7 @@ class TestJacket<T extends react.Component/*?*/> {
   /// >     ```
   /// >     jacket.mountNode.querySelector(someSelectorThatTargetsTheRootNode);
   /// >     ```
-  Element/*?*/ getNode() {
+  Element? getNode() {
     if (!_isCompositeComponent && !_isDomComponent) {
       throw StateError(over_react.unindent('''
         getNode() is only supported when the rendered object is a DOM or composite (class based) component.
@@ -192,7 +192,7 @@ class TestJacket<T extends react.Component/*?*/> {
   /// > If you are rendering a function component using [mount], calling [getDartInstance] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
-  T/*?*/ getDartInstance() {
+  T? getDartInstance() {
     // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
     //     a DOM component (Element) - is to return `null`. While that will most likely cause null exceptions once the
     //     consumer attempts to make a call on the "Dart instance" they have requested - we don't want this change
@@ -203,7 +203,7 @@ class TestJacket<T extends react.Component/*?*/> {
           'getDartInstance() is only supported when the rendered object is a composite (class based) component.');
     }
 
-    return over_react.getDartComponent(_renderedInstance) as T/*?*/;
+    return over_react.getDartComponent(_renderedInstance) as T?;
   }
 
   /// Returns if the jacket component is mounted or not.
@@ -220,13 +220,13 @@ class TestJacket<T extends react.Component/*?*/> {
   /// > If you are rendering a function or DOM component using [mount], calling [setState] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
-  void setState(newState, [callback()/*?*/]) {
+  void setState(newState, [callback()?]) {
     if (!_isCompositeComponent) {
       throw StateError(
           'setState() is only supported when the rendered object is a composite (class based) component.');
     }
 
-    getDartInstance()/*!*/.setState(newState, callback);
+    getDartInstance()!.setState(newState, callback);
   }
 
   /// Unmounts the React component instance and cleans up any attached DOM nodes.

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -46,7 +46,7 @@ import './zone_util.dart';
 ///
 /// To have the instance not automatically unmounted when the test if over set [autoTearDown] to `false`.
 TestJacket<T> mount<T extends react.Component>(over_react.ReactElement reactElement, {
-    Element mountNode,
+    Element/*?*/ mountNode,
     bool attachedToDocument = false,
     bool autoTearDown = true
 }) {
@@ -58,16 +58,16 @@ TestJacket<T> mount<T extends react.Component>(over_react.ReactElement reactElem
 }
 
 /// Provides more a more consistent and easier to use API to test and manipulate a rendered [ReactComponent].
-class TestJacket<T extends react.Component> {
+class TestJacket<T extends react.Component/*?*/> {
 
-  TestJacket._(over_react.ReactElement reactElement, {Element mountNode, this.attachedToDocument = false, this.autoTearDown = true})
+  TestJacket._(over_react.ReactElement reactElement, {Element/*?*/ mountNode, this.attachedToDocument = false, this.autoTearDown = true})
       : mountNode = mountNode ?? (DivElement()
     ..style.height = '800px'
     ..style.width = '800px') {
     _render(reactElement);
   }
 
-  /* [1] */ Object _renderedInstance;
+  /* [1] */ Object/*?*/ _renderedInstance;
   final Element mountNode;
   final bool attachedToDocument;
   final bool autoTearDown;
@@ -115,7 +115,7 @@ class TestJacket<T extends react.Component> {
   /// >   ```
   /// >   queryByTestId(jacket.mountNode, yourTestId)
   /// >   ```
-  ReactComponent getInstance() {
+  ReactComponent/*?*/ getInstance() {
     // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
     //     a DOM component (Element) - does not throw. The cast to `ReactComponent` - while not "sound", is harmless
     //     since it is an anonymous JS interop class - not a Dart type.
@@ -137,7 +137,7 @@ class TestJacket<T extends react.Component> {
       '''));
     }
 
-    return _renderedInstance as ReactComponent;
+    return _renderedInstance as ReactComponent/*?*/;
   }
 
   /// Returns the props associated with the mounted React composite component instance.
@@ -169,7 +169,7 @@ class TestJacket<T extends react.Component> {
   /// >     ```
   /// >     jacket.mountNode.querySelector(someSelectorThatTargetsTheRootNode);
   /// >     ```
-  Element getNode() {
+  Element/*?*/ getNode() {
     if (!_isCompositeComponent && !_isDomComponent) {
       throw StateError(over_react.unindent('''
         getNode() is only supported when the rendered object is a DOM or composite (class based) component.
@@ -192,7 +192,7 @@ class TestJacket<T extends react.Component> {
   /// > If you are rendering a function component using [mount], calling [getDartInstance] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
-  T getDartInstance() {
+  T/*?*/ getDartInstance() {
     // [1] Adding an additional check for dom components here because the current behavior when `_renderedInstance` is
     //     a DOM component (Element) - is to return `null`. While that will most likely cause null exceptions once the
     //     consumer attempts to make a call on the "Dart instance" they have requested - we don't want this change
@@ -203,7 +203,7 @@ class TestJacket<T extends react.Component> {
           'getDartInstance() is only supported when the rendered object is a composite (class based) component.');
     }
 
-    return over_react.getDartComponent(_renderedInstance) as T;
+    return over_react.getDartComponent(_renderedInstance) as T/*?*/;
   }
 
   /// Returns if the jacket component is mounted or not.
@@ -220,13 +220,13 @@ class TestJacket<T extends react.Component> {
   /// > If you are rendering a function or DOM component using [mount], calling [setState] will throw a `StateError`.
   /// >
   /// > See [getInstance] for more information about this limitation.
-  void setState(newState, [callback()]) {
+  void setState(newState, [callback()/*?*/]) {
     if (!_isCompositeComponent) {
       throw StateError(
           'setState() is only supported when the rendered object is a composite (class based) component.');
     }
 
-    getDartInstance().setState(newState, callback);
+    getDartInstance()/*!*/.setState(newState, callback);
   }
 
   /// Unmounts the React component instance and cleans up any attached DOM nodes.

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/jacket.dart
+++ b/lib/src/over_react_test/jacket.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -233,7 +234,7 @@ class TestJacket<T extends react.Component?> {
   void unmount() {
     _isMounted = false;
     react_util.unmount(_renderedInstance);
-    mountNode?.remove();
+    mountNode.remove();
     react_util.tearDownAttachedNodes();
   }
 }

--- a/lib/src/over_react_test/js_component.dart
+++ b/lib/src/over_react_test/js_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/js_component.dart
+++ b/lib/src/over_react_test/js_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -20,7 +20,7 @@ import 'package:react/react_client/react_interop.dart';
 ///
 /// Returns `null` if [el] does not render a UiComponent2 or does not use the
 /// new mixin syntax (determined by whether accessing propsMeta throws).
-PropsMetaCollection getPropsMeta(ReactElement el) {
+PropsMetaCollection/*?*/ getPropsMeta(ReactElement el) {
   // ignore: invalid_use_of_protected_member
   final isComponent2 = ReactDartComponentVersion.fromType(el.type) == '2';
   if (!isComponent2) return null;

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -20,7 +20,7 @@ import 'package:react/react_client/react_interop.dart';
 ///
 /// Returns `null` if [el] does not render a UiComponent2 or does not use the
 /// new mixin syntax (determined by whether accessing propsMeta throws).
-PropsMetaCollection/*?*/ getPropsMeta(ReactElement el) {
+PropsMetaCollection? getPropsMeta(ReactElement el) {
   // ignore: invalid_use_of_protected_member
   final isComponent2 = ReactDartComponentVersion.fromType(el.type) == '2';
   if (!isComponent2) return null;

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -54,9 +54,9 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// [autoTearDown] to false. If [autoTearDown] is set to true once it will, if provided, call [autoTearDownCallback]
 /// once the component has been unmounted.
 /* [1] */ render(dynamic component,
-    {bool autoTearDown = true,
-    Element container,
-    Callback autoTearDownCallback}) {
+    {bool/*?*/ autoTearDown = true,
+    Element/*?*/ container,
+    Callback/*?*/ autoTearDownCallback}) {
   var renderedInstance;
   component = component is component_base.UiProps ? component() : component;
 
@@ -68,7 +68,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
     renderedInstance = react_dom.render(component, container);
   }
 
-  if (autoTearDown) {
+  if (autoTearDown/*!*/) {
     addTearDown(() {
       unmount(renderedInstance);
       if (autoTearDownCallback != null) autoTearDownCallback();
@@ -84,7 +84,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// [autoTearDown] to false.
 ///
 /// See: <https://facebook.github.io/react/docs/test-utils.html#shallow-rendering>.
-ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Callback autoTearDownCallback}) {
+ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Callback/*?*/ autoTearDownCallback}) {
   var renderer = react_test_utils.createRenderer();
   if (autoTearDown) {
     addTearDown(() {
@@ -106,7 +106,7 @@ ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Cal
 void unmount(dynamic instanceOrContainerNode) {
   if (instanceOrContainerNode == null) return;
 
-  Element containerNode;
+  /*late*/Element containerNode;
 
   if (instanceOrContainerNode is Element) {
     containerNode = instanceOrContainerNode;
@@ -136,7 +136,7 @@ void unmount(dynamic instanceOrContainerNode) {
 /// > If [component] is a function component, calling [renderAndGetDom] will throw a `StateError`.
 /// >
 /// > See `TestJacket.getNode` for more information about this limitation.
-Element renderAndGetDom(dynamic component, {bool autoTearDown = true, Callback autoTearDownCallback}) {
+Element/*?*/ renderAndGetDom(dynamic component, {bool autoTearDown = true, Callback/*?*/ autoTearDownCallback}) {
   final renderedInstance = render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback);
 
   if (!react_test_utils.isCompositeComponent(renderedInstance) && !react_test_utils.isDOMComponent(renderedInstance)) {
@@ -177,9 +177,9 @@ List<Element> _attachedReactContainers = [];
 ///
 /// Returns the rendered component.
 /* [1] */ renderAttachedToDocument(dynamic component,
-    {bool autoTearDown = true,
-    Element container,
-    Callback autoTearDownCallback}) {
+    {bool/*?*/ autoTearDown = true,
+    Element/*?*/ container,
+    Callback/*?*/ autoTearDownCallback}) {
   container ??= DivElement()
     // Set arbitrary height and width for container to ensure nothing is cut off.
     ..style.setProperty('width', '800px')
@@ -187,12 +187,12 @@ List<Element> _attachedReactContainers = [];
 
   setComponentZone();
 
-  document.body.append(container);
+  document.body/*!*/.append(container);
 
-  if (autoTearDown) {
+  if (autoTearDown/*!*/) {
     addTearDown(() {
       react_dom.unmountComponentAtNode(container);
-      container.remove();
+      container/*!*/.remove();
       if (autoTearDownCallback != null) autoTearDownCallback();
     });
   } else {
@@ -211,7 +211,7 @@ void tearDownAttachedNodes() {
   }
 }
 
-typedef void _EventSimulatorAlias(componentOrNode, [Map eventData]);
+typedef void _EventSimulatorAlias(componentOrNode, [Map/*?*/ eventData]);
 
 /// Helper function to simulate clicks
 final _EventSimulatorAlias click = react_test_utils.Simulate.click;
@@ -244,11 +244,11 @@ final _EventSimulatorAlias mouseDown = react_test_utils.Simulate.mouseDown;
 final _EventSimulatorAlias mouseUp = react_test_utils.Simulate.mouseUp;
 
 /// Helper function to simulate mouseEnter events.
-final _EventSimulatorAlias mouseEnter = (componentOrNode, [Map eventData = const {}]) =>
+final _EventSimulatorAlias mouseEnter = (componentOrNode, [Map/*?*/ eventData = const {}]) =>
     Simulate._mouseEnter(componentOrNode, jsifyAndAllowInterop(eventData));
 
 /// Helper function to simulate mouseLeave events.
-final _EventSimulatorAlias mouseLeave = (componentOrNode, [Map eventData = const {}]) =>
+final _EventSimulatorAlias mouseLeave = (componentOrNode, [Map/*?*/ eventData = const {}]) =>
     Simulate._mouseLeave(componentOrNode, jsifyAndAllowInterop(eventData));
 
 @JS('React.addons.TestUtils.Simulate')
@@ -261,7 +261,7 @@ abstract class Simulate {
 }
 
 /// Returns whether [props] contains [key] with a value set to a space-delimited string containing [value].
-bool _hasTestId(Map props, String key, String value) {
+bool _hasTestId(Map props, String key, String/*!*/ value) {
   var testId = props[key];
   return testId != null && splitSpaceDelimitedString(testId.toString()).contains(value);
 }
@@ -296,7 +296,7 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-/* [1] */ getByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+/* [1] */ getByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
   final results = getAllByTestId(root, value, key: key);
   return results.isEmpty ? null : results.first;
 }
@@ -343,7 +343,7 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+List /* < [1] > */ getAllByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
   if (root is react.Component) root = root.jsThis;
 
   if (isValidElement(root)) {
@@ -351,9 +351,9 @@ List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key = defa
   }
 
   return react_test_utils.findAllInRenderedTree(root, allowInterop((descendant) {
-    Map props;
+    Map/*?*/ props;
     if (react_test_utils.isDOMComponent(descendant)) {
-      props = findDomNode(descendant).attributes;
+      props = findDomNode(descendant)/*!*/.attributes;
     } else if (react_test_utils.isCompositeComponent(descendant)) {
       props = getProps(descendant);
     }
@@ -381,7 +381,7 @@ List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key = defa
 ///
 ///    // This returns [ `<Instance of 'ForwardsPropsComponent'>` ]
 ///    getAllComponentsByTestId(root, 'foo')
-List<T> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key = defaultTestIdKey}) =>
+List<T/*!*/> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key = defaultTestIdKey}) =>
     getAllByTestId(root, value, key: key)
         .map((element) => getDartComponent<T>(element)) // ignore: unnecessary_lambdas
         .where((component) => component != null)
@@ -415,7 +415,7 @@ List<T> getAllComponentsByTestId<T extends react.Component>(dynamic root, String
 ///     getComponentRootDomByTestId(renderedInstance, 'value'); // returns the `outer` `<div>`
 ///
 /// Related: [queryByTestId].
-Element getComponentRootDomByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+Element/*?*/ getComponentRootDomByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   return findDomNode(getByTestId(root, value, key: key));
 }
 
@@ -450,7 +450,7 @@ Element getComponentRootDomByTestId(dynamic root, String value, {String key = de
 ///     queryByTestId(renderedInstance, 'value'); // returns the `inner` `<div>`
 ///
 /// Related: [queryAllByTestId], [getComponentRootDomByTestId].
-Element queryByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int shadowDepth}) {
+Element/*?*/ queryByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int/*?*/ shadowDepth}) {
   var results = _findDeep(findDomNode(root), _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: false, depth: shadowDepth);
   return results.isNotEmpty ? results.first : null;
 }
@@ -490,15 +490,15 @@ Element queryByTestId(dynamic root, String value, {String key = defaultTestIdKey
 ///     </div>
 ///
 ///     queryAllByTestId(renderedInstance, 'value'); // returns both `inner` `<div>`s
-List<Element> queryAllByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int shadowDepth}) {
+List<Element> queryAllByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int/*?*/ shadowDepth}) {
   return _findDeep(findDomNode(root), _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: true, depth: shadowDepth);
 }
 
 String _makeTestIdSelector(String value, {String key = defaultTestIdKey}) => '[$key~="$value"]';
 
-List<Element> _findDeep(Node root, String itemSelector, {bool searchInShadowDom = false, bool findMany = true, int depth}) {
+List<Element> _findDeep(Node/*!*/ root, String itemSelector, {bool searchInShadowDom = false, bool findMany = true, int/*?*/ depth}) {
   List<Element> nodes = [];
-  void recursiveSeek(Node _root, int _currentDepth) {
+  void recursiveSeek(Node/*!*/ _root, int _currentDepth) {
     // The LHS type prevents `rootQuerySelectorAll` from returning `_FrozenElementList<JSObject<undefined>>` instead of `<Element>` in DDC
     final List<Element> Function(String) rootQuerySelectorAll = _root is ShadowRoot ? _root.querySelectorAll : _root is Element ? _root.querySelectorAll : null;
     nodes.addAll(rootQuerySelectorAll(itemSelector));
@@ -518,7 +518,7 @@ List<Element> _findDeep(Node root, String itemSelector, {bool searchInShadowDom 
 /// Returns the [react.Component] of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-react.Component getComponentByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+react.Component/*?*/ getComponentByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getDartComponent(instance);
@@ -530,7 +530,7 @@ react.Component getComponentByTestId(dynamic root, String value, {String key = d
 /// Returns the props of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-Map getPropsByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+Map/*?*/ getPropsByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getProps(instance);
@@ -539,7 +539,7 @@ Map getPropsByTestId(dynamic root, String value, {String key = defaultTestIdKey}
   return null;
 }
 
-List<ReactElement> _getAllByTestIdShallow(ReactElement root, String value, {String key = defaultTestIdKey}) {
+List<ReactElement/*!*/> _getAllByTestIdShallow(ReactElement/*!*/ root, String/*!*/ value, {String key = defaultTestIdKey}) {
   Iterable flattenChildren(dynamic children) sync* {
     if (children is Iterable) {
       yield* children.expand(flattenChildren);
@@ -548,7 +548,7 @@ List<ReactElement> _getAllByTestIdShallow(ReactElement root, String value, {Stri
     }
   }
 
-  final matchingDescendants = <ReactElement>[];
+  final matchingDescendants = <ReactElement/*!*/>[];
 
   var breadthFirstDescendants = Queue()..add(root);
   while (breadthFirstDescendants.isNotEmpty) {
@@ -575,9 +575,9 @@ List findDescendantsWithProp(/* [1] */ root, dynamic propKey) {
       return false;
     }
 
-    Map props;
+    Map/*?*/ props;
     if (react_test_utils.isDOMComponent(descendant)) {
-      props = findDomNode(descendant).attributes;
+      props = findDomNode(descendant)/*!*/.attributes;
     } else if (react_test_utils.isCompositeComponent(descendant)) {
       props = getProps(descendant);
     }

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -297,7 +297,7 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-/* [1] */ getByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+/* [1] */ getByTestId(dynamic root, String? value, {String key = defaultTestIdKey}) {
   final results = getAllByTestId(root, value, key: key);
   return results.isEmpty ? null : results.first;
 }
@@ -344,7 +344,8 @@ bool _hasTestId(Map props, String key, String value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+List /* < [1] > */ getAllByTestId(dynamic root, String? value, {String key = defaultTestIdKey}) {
+  if (value == null || value.toLowerCase() == 'null') return [];
   if (root is react.Component) root = root.jsThis;
 
   if (isValidElement(root)) {
@@ -501,7 +502,7 @@ List<Element> _findDeep(Node root, String itemSelector, {bool searchInShadowDom 
   List<Element> nodes = [];
   void recursiveSeek(Node _root, int _currentDepth) {
     // The LHS type prevents `rootQuerySelectorAll` from returning `_FrozenElementList<JSObject<undefined>>` instead of `<Element>` in DDC
-    final List<Element> Function(String) rootQuerySelectorAll = _root is ShadowRoot ? _root.querySelectorAll : _root is Element ? _root.querySelectorAll : null;
+    final List<Element> Function(String) rootQuerySelectorAll = _root is ShadowRoot ? _root.querySelectorAll : _root is Element ? _root.querySelectorAll : (String s) => [];
     nodes.addAll(rootQuerySelectorAll(itemSelector));
     if (!findMany && nodes.isNotEmpty) {
       return;
@@ -519,7 +520,7 @@ List<Element> _findDeep(Node root, String itemSelector, {bool searchInShadowDom 
 /// Returns the [react.Component] of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-react.Component? getComponentByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+react.Component? getComponentByTestId(dynamic root, String? value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getDartComponent(instance);
@@ -531,7 +532,7 @@ react.Component? getComponentByTestId(dynamic root, String value, {String key = 
 /// Returns the props of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-Map? getPropsByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+Map? getPropsByTestId(dynamic root, String? value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getProps(instance);

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -18,6 +18,7 @@ library over_react_test.react_util;
 import 'dart:collection';
 import 'dart:html';
 
+import 'package:collection/collection.dart' show IterableNullableExtension;
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/component_base.dart' as component_base;
@@ -54,9 +55,9 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// [autoTearDown] to false. If [autoTearDown] is set to true once it will, if provided, call [autoTearDownCallback]
 /// once the component has been unmounted.
 /* [1] */ render(dynamic component,
-    {bool/*?*/ autoTearDown = true,
-    Element/*?*/ container,
-    Callback/*?*/ autoTearDownCallback}) {
+    {bool? autoTearDown = true,
+    Element? container,
+    Callback? autoTearDownCallback}) {
   var renderedInstance;
   component = component is component_base.UiProps ? component() : component;
 
@@ -68,7 +69,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
     renderedInstance = react_dom.render(component, container);
   }
 
-  if (autoTearDown/*!*/) {
+  if (autoTearDown!) {
     addTearDown(() {
       unmount(renderedInstance);
       if (autoTearDownCallback != null) autoTearDownCallback();
@@ -84,7 +85,7 @@ export 'package:over_react/src/util/react_wrappers.dart';
 /// [autoTearDown] to false.
 ///
 /// See: <https://facebook.github.io/react/docs/test-utils.html#shallow-rendering>.
-ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Callback/*?*/ autoTearDownCallback}) {
+ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Callback? autoTearDownCallback}) {
   var renderer = react_test_utils.createRenderer();
   if (autoTearDown) {
     addTearDown(() {
@@ -106,7 +107,7 @@ ReactElement renderShallow(ReactElement instance, {bool autoTearDown = true, Cal
 void unmount(dynamic instanceOrContainerNode) {
   if (instanceOrContainerNode == null) return;
 
-  /*late*/Element containerNode;
+  late Element? containerNode;
 
   if (instanceOrContainerNode is Element) {
     containerNode = instanceOrContainerNode;
@@ -136,7 +137,7 @@ void unmount(dynamic instanceOrContainerNode) {
 /// > If [component] is a function component, calling [renderAndGetDom] will throw a `StateError`.
 /// >
 /// > See `TestJacket.getNode` for more information about this limitation.
-Element/*?*/ renderAndGetDom(dynamic component, {bool autoTearDown = true, Callback/*?*/ autoTearDownCallback}) {
+Element? renderAndGetDom(dynamic component, {bool autoTearDown = true, Callback? autoTearDownCallback}) {
   final renderedInstance = render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback);
 
   if (!react_test_utils.isCompositeComponent(renderedInstance) && !react_test_utils.isDOMComponent(renderedInstance)) {
@@ -152,8 +153,8 @@ Element/*?*/ renderAndGetDom(dynamic component, {bool autoTearDown = true, Callb
 /// > If [component] is a function component, calling [renderAndGetComponent] will throw a `StateError`.
 /// >
 /// > See `TestJacket.getInstance` for more information about this limitation.
-react.Component renderAndGetComponent(dynamic component,
-        {bool autoTearDown = true, Callback autoTearDownCallback}) {
+react.Component? renderAndGetComponent(dynamic component,
+        {bool autoTearDown = true, Callback? autoTearDownCallback}) {
   final renderedInstance = render(component, autoTearDown: autoTearDown, autoTearDownCallback: autoTearDownCallback);
 
   // [1] Adding an additional check for dom components here because the current behavior when `renderedInstance` is
@@ -177,9 +178,9 @@ List<Element> _attachedReactContainers = [];
 ///
 /// Returns the rendered component.
 /* [1] */ renderAttachedToDocument(dynamic component,
-    {bool/*?*/ autoTearDown = true,
-    Element/*?*/ container,
-    Callback/*?*/ autoTearDownCallback}) {
+    {bool? autoTearDown = true,
+    Element? container,
+    Callback? autoTearDownCallback}) {
   container ??= DivElement()
     // Set arbitrary height and width for container to ensure nothing is cut off.
     ..style.setProperty('width', '800px')
@@ -187,12 +188,12 @@ List<Element> _attachedReactContainers = [];
 
   setComponentZone();
 
-  document.body/*!*/.append(container);
+  document.body!.append(container);
 
-  if (autoTearDown/*!*/) {
+  if (autoTearDown!) {
     addTearDown(() {
       react_dom.unmountComponentAtNode(container);
-      container/*!*/.remove();
+      container!.remove();
       if (autoTearDownCallback != null) autoTearDownCallback();
     });
   } else {
@@ -211,7 +212,7 @@ void tearDownAttachedNodes() {
   }
 }
 
-typedef void _EventSimulatorAlias(componentOrNode, [Map/*?*/ eventData]);
+typedef void _EventSimulatorAlias(componentOrNode, [Map? eventData]);
 
 /// Helper function to simulate clicks
 final _EventSimulatorAlias click = react_test_utils.Simulate.click;
@@ -244,11 +245,11 @@ final _EventSimulatorAlias mouseDown = react_test_utils.Simulate.mouseDown;
 final _EventSimulatorAlias mouseUp = react_test_utils.Simulate.mouseUp;
 
 /// Helper function to simulate mouseEnter events.
-final _EventSimulatorAlias mouseEnter = (componentOrNode, [Map/*?*/ eventData = const {}]) =>
+final _EventSimulatorAlias mouseEnter = (componentOrNode, [Map? eventData = const {}]) =>
     Simulate._mouseEnter(componentOrNode, jsifyAndAllowInterop(eventData));
 
 /// Helper function to simulate mouseLeave events.
-final _EventSimulatorAlias mouseLeave = (componentOrNode, [Map/*?*/ eventData = const {}]) =>
+final _EventSimulatorAlias mouseLeave = (componentOrNode, [Map? eventData = const {}]) =>
     Simulate._mouseLeave(componentOrNode, jsifyAndAllowInterop(eventData));
 
 @JS('React.addons.TestUtils.Simulate')
@@ -261,7 +262,7 @@ abstract class Simulate {
 }
 
 /// Returns whether [props] contains [key] with a value set to a space-delimited string containing [value].
-bool _hasTestId(Map props, String key, String/*!*/ value) {
+bool _hasTestId(Map props, String key, String value) {
   var testId = props[key];
   return testId != null && splitSpaceDelimitedString(testId.toString()).contains(value);
 }
@@ -296,7 +297,7 @@ bool _hasTestId(Map props, String key, String/*!*/ value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-/* [1] */ getByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
+/* [1] */ getByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   final results = getAllByTestId(root, value, key: key);
   return results.isEmpty ? null : results.first;
 }
@@ -343,7 +344,7 @@ bool _hasTestId(Map props, String key, String/*!*/ value) {
 ///
 /// It is recommended that, instead of setting this [key] prop manually, you should use the
 /// [UiProps.addTestId] method so the prop is only set in a test environment.
-List /* < [1] > */ getAllByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
+List /* < [1] > */ getAllByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   if (root is react.Component) root = root.jsThis;
 
   if (isValidElement(root)) {
@@ -351,9 +352,9 @@ List /* < [1] > */ getAllByTestId(dynamic root, String/*!*/ value, {String key =
   }
 
   return react_test_utils.findAllInRenderedTree(root, allowInterop((descendant) {
-    Map/*?*/ props;
+    Map? props;
     if (react_test_utils.isDOMComponent(descendant)) {
-      props = findDomNode(descendant)/*!*/.attributes;
+      props = findDomNode(descendant)!.attributes;
     } else if (react_test_utils.isCompositeComponent(descendant)) {
       props = getProps(descendant);
     }
@@ -381,10 +382,10 @@ List /* < [1] > */ getAllByTestId(dynamic root, String/*!*/ value, {String key =
 ///
 ///    // This returns [ `<Instance of 'ForwardsPropsComponent'>` ]
 ///    getAllComponentsByTestId(root, 'foo')
-List<T/*!*/> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key = defaultTestIdKey}) =>
+List<T> getAllComponentsByTestId<T extends react.Component>(dynamic root, String value, {String key = defaultTestIdKey}) =>
     getAllByTestId(root, value, key: key)
         .map((element) => getDartComponent<T>(element)) // ignore: unnecessary_lambdas
-        .where((component) => component != null)
+        .whereNotNull()
         .toList();
 
 /// Returns the [Element] of the first descendant of [root] that has its [key] prop value set to [value].
@@ -415,7 +416,7 @@ List<T/*!*/> getAllComponentsByTestId<T extends react.Component>(dynamic root, S
 ///     getComponentRootDomByTestId(renderedInstance, 'value'); // returns the `outer` `<div>`
 ///
 /// Related: [queryByTestId].
-Element/*?*/ getComponentRootDomByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
+Element? getComponentRootDomByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   return findDomNode(getByTestId(root, value, key: key));
 }
 
@@ -450,8 +451,8 @@ Element/*?*/ getComponentRootDomByTestId(dynamic root, String value, {String key
 ///     queryByTestId(renderedInstance, 'value'); // returns the `inner` `<div>`
 ///
 /// Related: [queryAllByTestId], [getComponentRootDomByTestId].
-Element/*?*/ queryByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int/*?*/ shadowDepth}) {
-  var results = _findDeep(findDomNode(root), _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: false, depth: shadowDepth);
+Element? queryByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
+  var results = _findDeep(findDomNode(root)!, _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: false, depth: shadowDepth);
   return results.isNotEmpty ? results.first : null;
 }
 
@@ -490,15 +491,15 @@ Element/*?*/ queryByTestId(dynamic root, String value, {String key = defaultTest
 ///     </div>
 ///
 ///     queryAllByTestId(renderedInstance, 'value'); // returns both `inner` `<div>`s
-List<Element> queryAllByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int/*?*/ shadowDepth}) {
-  return _findDeep(findDomNode(root), _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: true, depth: shadowDepth);
+List<Element> queryAllByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
+  return _findDeep(findDomNode(root)!, _makeTestIdSelector(value, key: key), searchInShadowDom: searchInShadowDom, findMany: true, depth: shadowDepth);
 }
 
 String _makeTestIdSelector(String value, {String key = defaultTestIdKey}) => '[$key~="$value"]';
 
-List<Element> _findDeep(Node/*!*/ root, String itemSelector, {bool searchInShadowDom = false, bool findMany = true, int/*?*/ depth}) {
+List<Element> _findDeep(Node root, String itemSelector, {bool searchInShadowDom = false, bool findMany = true, int? depth}) {
   List<Element> nodes = [];
-  void recursiveSeek(Node/*!*/ _root, int _currentDepth) {
+  void recursiveSeek(Node _root, int _currentDepth) {
     // The LHS type prevents `rootQuerySelectorAll` from returning `_FrozenElementList<JSObject<undefined>>` instead of `<Element>` in DDC
     final List<Element> Function(String) rootQuerySelectorAll = _root is ShadowRoot ? _root.querySelectorAll : _root is Element ? _root.querySelectorAll : null;
     nodes.addAll(rootQuerySelectorAll(itemSelector));
@@ -508,7 +509,7 @@ List<Element> _findDeep(Node/*!*/ root, String itemSelector, {bool searchInShado
     // This method of finding shadow roots may not be performant, but it's good enough for usage in tests.
     if (searchInShadowDom && (depth == null || _currentDepth < depth)) {
       var foundShadows = rootQuerySelectorAll('*').where((el) => el.shadowRoot != null).map((el) => el.shadowRoot).toList();
-      foundShadows.forEach((shadowRoot) => recursiveSeek(shadowRoot, _currentDepth + 1));
+      foundShadows.forEach((shadowRoot) => recursiveSeek(shadowRoot!, _currentDepth + 1));
     }
   }
   recursiveSeek(root, 0);
@@ -518,7 +519,7 @@ List<Element> _findDeep(Node/*!*/ root, String itemSelector, {bool searchInShado
 /// Returns the [react.Component] of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-react.Component/*?*/ getComponentByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
+react.Component? getComponentByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getDartComponent(instance);
@@ -530,7 +531,7 @@ react.Component/*?*/ getComponentByTestId(dynamic root, String/*!*/ value, {Stri
 /// Returns the props of the first descendant of [root] that has its [key] prop value set to [value].
 ///
 /// Returns null if no descendant has its [key] prop value set to [value].
-Map/*?*/ getPropsByTestId(dynamic root, String/*!*/ value, {String key = defaultTestIdKey}) {
+Map? getPropsByTestId(dynamic root, String value, {String key = defaultTestIdKey}) {
   var instance = getByTestId(root, value, key: key);
   if (instance != null) {
     return getProps(instance);
@@ -539,7 +540,7 @@ Map/*?*/ getPropsByTestId(dynamic root, String/*!*/ value, {String key = default
   return null;
 }
 
-List<ReactElement/*!*/> _getAllByTestIdShallow(ReactElement/*!*/ root, String/*!*/ value, {String key = defaultTestIdKey}) {
+List<ReactElement> _getAllByTestIdShallow(ReactElement root, String value, {String key = defaultTestIdKey}) {
   Iterable flattenChildren(dynamic children) sync* {
     if (children is Iterable) {
       yield* children.expand(flattenChildren);
@@ -548,7 +549,7 @@ List<ReactElement/*!*/> _getAllByTestIdShallow(ReactElement/*!*/ root, String/*!
     }
   }
 
-  final matchingDescendants = <ReactElement/*!*/>[];
+  final matchingDescendants = <ReactElement>[];
 
   var breadthFirstDescendants = Queue()..add(root);
   while (breadthFirstDescendants.isNotEmpty) {
@@ -575,9 +576,9 @@ List findDescendantsWithProp(/* [1] */ root, dynamic propKey) {
       return false;
     }
 
-    Map/*?*/ props;
+    Map? props;
     if (react_test_utils.isDOMComponent(descendant)) {
-      props = findDomNode(descendant)/*!*/.attributes;
+      props = findDomNode(descendant)!.attributes;
     } else if (react_test_utils.isCompositeComponent(descendant)) {
       props = getProps(descendant);
     }

--- a/lib/src/over_react_test/test_helpers.dart
+++ b/lib/src/over_react_test/test_helpers.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/lib/src/over_react_test/test_helpers.dart
+++ b/lib/src/over_react_test/test_helpers.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 import 'dart:async';
 
 import 'package:test/test.dart';

--- a/lib/src/over_react_test/validation_util.dart
+++ b/lib/src/over_react_test/validation_util.dart
@@ -160,17 +160,17 @@ void verifyValidationWarning(dynamic warningMatcher) {
 /// [startRecordingValidationWarnings] was first called.
 ///
 /// > Related: [clearValidationWarnings]
-List<String> getValidationWarnings() => _validationWarnings?.toList();
+List<String>? getValidationWarnings() => _validationWarnings?.toList();
 
 /// Clears the list of [ValidationUtil.warn]ings that have been recorded since
 /// [startRecordingValidationWarnings] was first called.
 ///
 /// > Related: [getValidationWarnings]
 void clearValidationWarnings() {
-  _validationWarnings.clear();
+  _validationWarnings!.clear();
 }
 
-List<String>/*?*/ _validationWarnings;
+List<String>? _validationWarnings;
 void _recordValidationWarning(String warningMessage) {
-  _validationWarnings/*!*/.add(warningMessage);
+  _validationWarnings!.add(warningMessage);
 }

--- a/lib/src/over_react_test/validation_util.dart
+++ b/lib/src/over_react_test/validation_util.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/validation_util.dart
+++ b/lib/src/over_react_test/validation_util.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/validation_util.dart
+++ b/lib/src/over_react_test/validation_util.dart
@@ -170,7 +170,7 @@ void clearValidationWarnings() {
   _validationWarnings.clear();
 }
 
-List<String> _validationWarnings;
+List<String>/*?*/ _validationWarnings;
 void _recordValidationWarning(String warningMessage) {
-  _validationWarnings.add(warningMessage);
+  _validationWarnings/*!*/.add(warningMessage);
 }

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/wrapper_component.dart
+++ b/lib/src/over_react_test/wrapper_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';
 
-Zone _zone;
+Zone/*?*/ _zone;
 
 /// Validates that [storeZone] was called before [zonedExpect] was.
 void validateZone() {
@@ -28,7 +28,7 @@ void validateZone() {
 
 /// Store the specified _(or current if none is specified)_ [zone]
 /// for use within [zonedExpect].
-void storeZone([Zone zone]) {
+void storeZone([Zone/*?*/ zone]) {
   if (zone == null) {
     zone = Zone.current;
   }
@@ -38,10 +38,10 @@ void storeZone([Zone zone]) {
 /// Calls [expect] in package:test/test.dart in the zone stored in [storeZone].
 ///
 /// Useful for expectations in blocks called in other zones.
-void zonedExpect(actual, matcher, {String reason}) {
+void zonedExpect(actual, matcher, {String/*?*/ reason}) {
   validateZone();
 
-  return _zone.run(() {
+  return _zone/*!*/.run(() {
     expect(actual, matcher, reason: reason);
   });
 }
@@ -73,6 +73,6 @@ void zonedExpect(actual, matcher, {String reason}) {
 ///       renderIntoDocument((
 ///           TestComponent()..onComponentDidMount = shouldPassTest)()); // Passes
 ///     });
-void setComponentZone([Zone zone]) {
+void setComponentZone([Zone/*?*/ zone]) {
   componentZone = zone ?? Zone.current;
 }

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';
 
-Zone/*?*/ _zone;
+Zone? _zone;
 
 /// Validates that [storeZone] was called before [zonedExpect] was.
 void validateZone() {
@@ -28,7 +28,7 @@ void validateZone() {
 
 /// Store the specified _(or current if none is specified)_ [zone]
 /// for use within [zonedExpect].
-void storeZone([Zone/*?*/ zone]) {
+void storeZone([Zone? zone]) {
   if (zone == null) {
     zone = Zone.current;
   }
@@ -38,10 +38,10 @@ void storeZone([Zone/*?*/ zone]) {
 /// Calls [expect] in package:test/test.dart in the zone stored in [storeZone].
 ///
 /// Useful for expectations in blocks called in other zones.
-void zonedExpect(actual, matcher, {String/*?*/ reason}) {
+void zonedExpect(actual, matcher, {String? reason}) {
   validateZone();
 
-  return _zone/*!*/.run(() {
+  return _zone!.run(() {
     expect(actual, matcher, reason: reason);
   });
 }
@@ -73,6 +73,6 @@ void zonedExpect(actual, matcher, {String/*?*/ reason}) {
 ///       renderIntoDocument((
 ///           TestComponent()..onComponentDidMount = shouldPassTest)()); // Passes
 ///     });
-void setComponentZone([Zone/*?*/ zone]) {
+void setComponentZone([Zone? zone]) {
   componentZone = zone ?? Zone.current;
 }

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/over_react_test/zone_util.dart
+++ b/lib/src/over_react_test/zone_util.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,13 +24,13 @@ dependency_overrides:
   w_common: ^3.0.0
   w_flux:
     git:
-      url: git@github.com:Workiva/w_flux.git
+      url: https://github.com/Workiva/w_flux
       ref: null-safety
   over_react:
     git:
-      url: git@github.com:Workiva/over_react.git
+      url: https://github.com/Workiva/over_react
       ref: null-safety
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart
       ref: null-safety-manual

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependency_overrides:
   w_common: ^3.0.0
   dart_dev:
     git:
-      ref: fix_up_null_safety
+      ref: fix_up_null_safety_hunter
       url: https://github.com/Workiva/dart_dev
   w_flux:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   matcher: ^0.12.1+4
   meta: ^1.8.0
   over_react: ^4.1.2
-  react: '>=6.0.1 <8.0.0'
+  react: ^7.0.0
   test: ^1.21.1
 dev_dependencies:
   dart_dev: ^4.0.0
@@ -35,7 +35,4 @@ dependency_overrides:
     git:
       url: https://github.com/Workiva/over_react
       ref: null-safety
-  react:
-    git:
-      url: https://github.com/Workiva/react-dart
-      ref: null-safety-manual
+  react: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,3 +18,18 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
   pedantic: ^1.8.0
+
+dependency_overrides:
+  w_common: ^3.0.0
+  w_flux:
+    git:
+      url: git@github.com:Workiva/w_flux.git
+      ref: null-safety
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: null-safety
+  react:
+    git:
+      url: git@github.com:Workiva/react-dart.git
+      ref: null-safety-manual

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,12 +27,7 @@ dependency_overrides:
     git:
       ref: fix_up_null_safety_hunter
       url: https://github.com/Workiva/dart_dev
-  w_flux:
-    git:
-      url: https://github.com/Workiva/w_flux
-      ref: null-safety
   over_react:
     git:
       url: https://github.com/Workiva/over_react
       ref: null-safety
-  react: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 2.11.5
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 environment:
-  sdk: ">=2.11.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   js: ^0.6.1+1
@@ -12,6 +12,7 @@ dependencies:
   over_react: ^4.1.2
   react: ^6.0.1
   test: ^1.15.7
+  collection: ^1.15.0-nullsafety.4
 dev_dependencies:
   build_runner: ^2.1.2
   build_test: ^2.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   meta: ^1.6.0
   over_react: ^4.1.2
   react: ^6.0.1
-  test: ^1.15.7
+  test: ^1.20.0
   collection: ^1.15.0-nullsafety.4
+
 dev_dependencies:
+  dart_dev: ^4.0.0
   build_runner: ^2.1.2
   build_test: ^2.1.3
   build_web_compilers: ^3.0.0
@@ -22,6 +24,10 @@ dev_dependencies:
 
 dependency_overrides:
   w_common: ^3.0.0
+  dart_dev:
+    git:
+      ref: fix_up_null_safety
+      url: https://github.com/Workiva/dart_dev
   w_flux:
     git:
       url: https://github.com/Workiva/w_flux

--- a/test/over_react_test.dart
+++ b/test/over_react_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test.dart
+++ b/test/over_react_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -48,7 +48,7 @@ main() {
     });
 
     group('should skip checking for certain props', () {
-      final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()());
+      final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()())/*!*/;
       final consumedKeys = meta.forMixin(new_boilerplate.ShouldNotBeForwardedProps).keys;
       final skippedKey = consumedKeys.first;
 
@@ -93,7 +93,7 @@ main() {
     group('does not call `factory` directly within the consuming group', () {
       void sharedTest(
         BuilderOnlyUiFactory factory, {
-        List Function(PropsMetaCollection) getUnconsumedPropKeys,
+        List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
       }) {
         var wasFactoryCalled = false;
 
@@ -161,7 +161,7 @@ main() {
       void expectedFailGroup(String description, void Function() groupBody, {@required dynamic testFailureMatcher}) {
         group(description, () {
           int totalTestCount = 0;
-          List<TestFailure> testFailureErrors;
+          /*late*/List<TestFailure> testFailureErrors;
           setUpAll(() => testFailureErrors = []);
 
           void testButReAndIgnoreExceptions(name, testBody) {
@@ -250,9 +250,9 @@ const UiFactory<UiProps> arbitraryUiFactory = domProps;
 
 UiFactory<UiProps> registerHelperComponent({
   @required HelperRenderFunction render,
-  Map defaultProps,
-  Iterable<ConsumedProps> consumedProps,
-  PropsMetaCollection propsMeta,
+  Map/*?*/ defaultProps,
+  Iterable<ConsumedProps>/*?*/ consumedProps,
+  PropsMetaCollection/*?*/ propsMeta,
 }) {
   final factory = registerComponent2(() {
     return CommonHelperComponent(
@@ -263,7 +263,7 @@ UiFactory<UiProps> registerHelperComponent({
       );
   });
 
-  return ([Map backingMap]) => arbitraryUiFactory(backingMap)..componentFactory = factory;
+  return ([Map/*?*/ backingMap]) => arbitraryUiFactory(backingMap)..componentFactory = factory;
 }
 
 class CommonHelperComponent extends UiComponent2<UiProps> {
@@ -273,9 +273,9 @@ class CommonHelperComponent extends UiComponent2<UiProps> {
   final HelperRenderFunction renderValue;
 
   CommonHelperComponent({
-    @required Map defaultPropsValue,
-    @required Iterable<ConsumedProps> consumedPropsValue,
-    @required PropsMetaCollection propsMetaValue,
+    @required Map/*?*/ defaultPropsValue,
+    @required Iterable<ConsumedProps>/*?*/ consumedPropsValue,
+    @required PropsMetaCollection/*?*/ propsMetaValue,
     @required this.renderValue,
   }) :
     defaultPropsValue = defaultPropsValue ?? {},

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -48,7 +48,7 @@ main() {
     });
 
     group('should skip checking for certain props', () {
-      final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()())/*!*/;
+      final meta = getPropsMeta(new_boilerplate.TestCommonForwarding()())!;
       final consumedKeys = meta.forMixin(new_boilerplate.ShouldNotBeForwardedProps).keys;
       final skippedKey = consumedKeys.first;
 
@@ -93,7 +93,7 @@ main() {
     group('does not call `factory` directly within the consuming group', () {
       void sharedTest(
         BuilderOnlyUiFactory factory, {
-        List Function(PropsMetaCollection)/*?*/ getUnconsumedPropKeys,
+        List Function(PropsMetaCollection)? getUnconsumedPropKeys,
       }) {
         var wasFactoryCalled = false;
 
@@ -158,10 +158,10 @@ main() {
       /// Declares a [group] in which tests declared via [testFunction] are expected to fail
       /// with an error matching [testFailureMatcher].
       @isTestGroup
-      void expectedFailGroup(String description, void Function() groupBody, {@required dynamic testFailureMatcher}) {
+      void expectedFailGroup(String description, void Function() groupBody, {required dynamic testFailureMatcher}) {
         group(description, () {
           int totalTestCount = 0;
-          /*late*/List<TestFailure> testFailureErrors;
+          late List<TestFailure> testFailureErrors;
           setUpAll(() => testFailureErrors = []);
 
           void testButReAndIgnoreExceptions(name, testBody) {
@@ -199,7 +199,7 @@ main() {
       });
 
       expectedFailGroup('forwards consumed props -', () {
-        final factory = registerHelperComponent(
+        final UiProps Function([Map<dynamic, dynamic>]) factory = registerHelperComponent(
           propsMeta: testPropsMeta,
           consumedProps: testPropsMeta.all,
           render: (component) => (Wrapper()..addAll(component.props))(),
@@ -213,7 +213,7 @@ main() {
       }, testFailureMatcher: contains('Unexpected keys on forwarding target'));
 
       expectedFailGroup('does not forward all of the unconsumed props in propsMeta -', () {
-        var factory = registerHelperComponent(
+        UiProps Function([Map<dynamic, dynamic>]) factory = registerHelperComponent(
           propsMeta: testPropsMeta,
           consumedProps: [],
           render: (component) => (Wrapper()
@@ -249,10 +249,10 @@ typedef HelperRenderFunction = dynamic Function(CommonHelperComponent component)
 const UiFactory<UiProps> arbitraryUiFactory = domProps;
 
 UiFactory<UiProps> registerHelperComponent({
-  @required HelperRenderFunction render,
-  Map/*?*/ defaultProps,
-  Iterable<ConsumedProps>/*?*/ consumedProps,
-  PropsMetaCollection/*?*/ propsMeta,
+  required HelperRenderFunction render,
+  Map? defaultProps,
+  Iterable<ConsumedProps>? consumedProps,
+  PropsMetaCollection? propsMeta,
 }) {
   final factory = registerComponent2(() {
     return CommonHelperComponent(
@@ -263,7 +263,7 @@ UiFactory<UiProps> registerHelperComponent({
       );
   });
 
-  return ([Map/*?*/ backingMap]) => arbitraryUiFactory(backingMap)..componentFactory = factory;
+  return ([Map? backingMap]) => arbitraryUiFactory(backingMap)..componentFactory = factory;
 }
 
 class CommonHelperComponent extends UiComponent2<UiProps> {
@@ -273,10 +273,10 @@ class CommonHelperComponent extends UiComponent2<UiProps> {
   final HelperRenderFunction renderValue;
 
   CommonHelperComponent({
-    @required Map/*?*/ defaultPropsValue,
-    @required Iterable<ConsumedProps>/*?*/ consumedPropsValue,
-    @required PropsMetaCollection/*?*/ propsMetaValue,
-    @required this.renderValue,
+    required Map? defaultPropsValue,
+    required Iterable<ConsumedProps>? consumedPropsValue,
+    required PropsMetaCollection? propsMetaValue,
+    required this.renderValue,
   }) :
     defaultPropsValue = defaultPropsValue ?? {},
     propsMetaValue = propsMetaValue ?? const PropsMetaCollection({}),
@@ -305,7 +305,7 @@ class CommonHelperComponent extends UiComponent2<UiProps> {
   @override
   typedPropsFactoryJs(map) => typedPropsFactory(map);
 
-  UiProps _cachedTypedProps;
+  late UiProps _cachedTypedProps;
 
   @override
   UiProps get props => _cachedTypedProps;

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/common_component_util_test.dart
+++ b/test/over_react_test/common_component_util_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -226,14 +226,14 @@ main() {
       var jacket = mount(Sample()(), attachedToDocument: true);
       var logs = await recordConsoleLogsAsync(() async {
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button');
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);
       }, configuration: warnConfig);
 
       expect(logs, hasLength(1));
-      expect(logs.first.contains('I have been clicked'), isTrue);
+      expect(logs.first/*!*/.contains('I have been clicked'), isTrue);
     });
 
     test('handles errors caused when rendering', () async {
@@ -298,7 +298,7 @@ main() {
         var jacket = mount((Sample()..addExtraLogAndWarn = true)(),
             attachedToDocument: true);
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button');
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);
@@ -312,7 +312,7 @@ main() {
         var jacket = mount((Sample()..addExtraLogAndWarn = true)(),
             attachedToDocument: true);
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button');
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -75,7 +75,7 @@ main() {
               configuration: errorConfig);
 
           expect(logs, hasLength(2));
-          expect(logs.firstWhere((log) => log.contains('shouldAlwaysBeFalse')),
+          expect(logs.firstWhere((log) => log!.contains('shouldAlwaysBeFalse')),
               contains('set to true'));
         });
 
@@ -226,14 +226,14 @@ main() {
       var jacket = mount(Sample()(), attachedToDocument: true);
       var logs = await recordConsoleLogsAsync(() async {
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')!;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);
       }, configuration: warnConfig);
 
       expect(logs, hasLength(1));
-      expect(logs.first/*!*/.contains('I have been clicked'), isTrue);
+      expect(logs.first!.contains('I have been clicked'), isTrue);
     });
 
     test('handles errors caused when rendering', () async {
@@ -298,7 +298,7 @@ main() {
         var jacket = mount((Sample()..addExtraLogAndWarn = true)(),
             attachedToDocument: true);
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')!;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);
@@ -312,7 +312,7 @@ main() {
         var jacket = mount((Sample()..addExtraLogAndWarn = true)(),
             attachedToDocument: true);
         var button =
-            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')/*!*/;
+            queryByTestId(jacket.getInstance(), 'ort_sample_component_button')!;
         await Future.delayed(Duration(milliseconds: 5));
 
         triggerDocumentClick(button);

--- a/test/over_react_test/console_log_utils_test.dart
+++ b/test/over_react_test/console_log_utils_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -26,7 +26,7 @@ import './helper_components/sample_component2.dart';
 /// Main entry point for CustomMatchers testing
 main() {
   group('CustomMatcher', () {
-    Element testElement;
+    late Element testElement;
 
     setUp(() {
       testElement = Element.div();
@@ -383,14 +383,14 @@ main() {
         List<Element> allAttachedNodes = [];
         Element makeAttachedNode() {
           var node = DivElement()..tabIndex = 1;
-          document.body/*!*/.append(node);
+          document.body!.append(node);
 
           allAttachedNodes.add(node);
 
           return node;
         }
 
-        Element attachedNode;
+        late Element attachedNode;
 
         setUp(() {
           attachedNode = makeAttachedNode();
@@ -445,7 +445,7 @@ main() {
 
     group('LoggingFunctionMatcher', () {
       group('when passed a List of logs', () {
-        List<String> logs;
+        late List<String> logs;
 
         setUp(() {
           logs = [
@@ -607,7 +607,7 @@ main() {
 
     group('PropTypeLogMatcher', () {
       group('when passed a List of logs', () {
-        List<String> logs;
+        late List<String> logs;
 
         setUp(() {
           logs = [
@@ -865,7 +865,7 @@ void shouldFail(value, Matcher matcher, expected) {
     if (expected is String) {
       expect(_errorString, equalsIgnoringWhitespace(expected));
     } else {
-      expect(_errorString/*!*/.replaceAll(RegExp(r'[\s\n]+'), ' '), expected);
+      expect(_errorString!.replaceAll(RegExp(r'[\s\n]+'), ' '), expected);
     }
   }
 

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/custom_matchers_test.dart
+++ b/test/over_react_test/custom_matchers_test.dart
@@ -383,7 +383,7 @@ main() {
         List<Element> allAttachedNodes = [];
         Element makeAttachedNode() {
           var node = DivElement()..tabIndex = 1;
-          document.body.append(node);
+          document.body/*!*/.append(node);
 
           allAttachedNodes.add(node);
 
@@ -865,7 +865,7 @@ void shouldFail(value, Matcher matcher, expected) {
     if (expected is String) {
       expect(_errorString, equalsIgnoringWhitespace(expected));
     } else {
-      expect(_errorString.replaceAll(RegExp(r'[\s\n]+'), ' '), expected);
+      expect(_errorString/*!*/.replaceAll(RegExp(r'[\s\n]+'), ' '), expected);
     }
   }
 

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -23,11 +23,11 @@ main() {
   test('triggerTransitionEnd correctly dispatches a transitionend event', () async {
     var flag = false;
 
-    document.body.onTransitionEnd.listen((Event event) {
+    document.body/*!*/.onTransitionEnd.listen((Event event) {
       flag = true;
     });
 
-    await triggerTransitionEnd(document.body);
+    await triggerTransitionEnd(document.body/*!*/);
 
     expect(flag, isTrue);
   });
@@ -42,7 +42,7 @@ main() {
     test('when the target is attached to the document', () {
       var renderedInstance = renderAttachedToDocument((Dom.div()..onClick = ((_) => flag = true))());
 
-      triggerDocumentClick(findDomNode(renderedInstance));
+      triggerDocumentClick(findDomNode(renderedInstance)/*!*/);
 
       expect(flag, isTrue);
     });
@@ -50,7 +50,7 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onClick = ((_) => flag = true))());
 
-      expect(() => triggerDocumentClick(findDomNode(renderedInstance)), throwsArgumentError);
+      expect(() => triggerDocumentClick(findDomNode(renderedInstance)/*!*/), throwsArgumentError);
       expect(flag, isFalse);
     });
   });
@@ -65,7 +65,7 @@ main() {
     test('when the target is attached to the document', () {
       var renderedInstance = renderAttachedToDocument((Dom.div()..onMouseDown = ((_) => flag = true))());
 
-      triggerDocumentMouseEvent(findDomNode(renderedInstance), 'mousedown');
+      triggerDocumentMouseEvent(findDomNode(renderedInstance)/*!*/, 'mousedown');
 
       expect(flag, isTrue);
     });
@@ -73,7 +73,7 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onMouseDown = ((_) => flag = true))());
 
-      expect(() => triggerDocumentMouseEvent(findDomNode(renderedInstance), 'mousedown'), throwsArgumentError);
+      expect(() => triggerDocumentMouseEvent(findDomNode(renderedInstance)/*!*/, 'mousedown'), throwsArgumentError);
       expect(flag, isFalse);
     });
   });
@@ -91,7 +91,7 @@ main() {
         ..tabIndex = '1'
       )());
 
-      await triggerFocus(findDomNode(renderedInstance));
+      await triggerFocus(findDomNode(renderedInstance)/*!*/);
 
       expect(flag, isTrue);
     });
@@ -99,7 +99,7 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onFocus = ((_) => flag = true))());
 
-      expect(() => triggerFocus(findDomNode(renderedInstance)), throwsArgumentError);
+      expect(() => triggerFocus(findDomNode(renderedInstance)/*!*/), throwsArgumentError);
       expect(flag, isFalse);
     });
   });

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -23,17 +23,17 @@ main() {
   test('triggerTransitionEnd correctly dispatches a transitionend event', () async {
     var flag = false;
 
-    document.body/*!*/.onTransitionEnd.listen((Event event) {
+    document.body!.onTransitionEnd.listen((Event event) {
       flag = true;
     });
 
-    await triggerTransitionEnd(document.body/*!*/);
+    await triggerTransitionEnd(document.body!);
 
     expect(flag, isTrue);
   });
 
   group('triggerDocumentClick correctly dispatches a click event', () {
-    var flag;
+    late var flag;
 
     setUp((){
       flag = false;
@@ -42,7 +42,7 @@ main() {
     test('when the target is attached to the document', () {
       var renderedInstance = renderAttachedToDocument((Dom.div()..onClick = ((_) => flag = true))());
 
-      triggerDocumentClick(findDomNode(renderedInstance)/*!*/);
+      triggerDocumentClick(findDomNode(renderedInstance)!);
 
       expect(flag, isTrue);
     });
@@ -50,13 +50,13 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onClick = ((_) => flag = true))());
 
-      expect(() => triggerDocumentClick(findDomNode(renderedInstance)/*!*/), throwsArgumentError);
+      expect(() => triggerDocumentClick(findDomNode(renderedInstance)!), throwsArgumentError);
       expect(flag, isFalse);
     });
   });
 
   group('triggerDocumentMouseEvent correctly dispatches an event', () {
-    var flag;
+    late var flag;
 
     setUp((){
       flag = false;
@@ -65,7 +65,7 @@ main() {
     test('when the target is attached to the document', () {
       var renderedInstance = renderAttachedToDocument((Dom.div()..onMouseDown = ((_) => flag = true))());
 
-      triggerDocumentMouseEvent(findDomNode(renderedInstance)/*!*/, 'mousedown');
+      triggerDocumentMouseEvent(findDomNode(renderedInstance)!, 'mousedown');
 
       expect(flag, isTrue);
     });
@@ -73,13 +73,13 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onMouseDown = ((_) => flag = true))());
 
-      expect(() => triggerDocumentMouseEvent(findDomNode(renderedInstance)/*!*/, 'mousedown'), throwsArgumentError);
+      expect(() => triggerDocumentMouseEvent(findDomNode(renderedInstance)!, 'mousedown'), throwsArgumentError);
       expect(flag, isFalse);
     });
   });
 
   group('triggerFocus correctly dispatches a focus event', () {
-    var flag;
+    late var flag;
 
     setUp((){
       flag = false;
@@ -91,7 +91,7 @@ main() {
         ..tabIndex = '1'
       )());
 
-      await triggerFocus(findDomNode(renderedInstance)/*!*/);
+      await triggerFocus(findDomNode(renderedInstance)!);
 
       expect(flag, isTrue);
     });
@@ -99,7 +99,7 @@ main() {
     test('and throws when the target is not attached to the document', () {
       var renderedInstance = render((Dom.div()..onFocus = ((_) => flag = true))());
 
-      expect(() => triggerFocus(findDomNode(renderedInstance)/*!*/), throwsArgumentError);
+      expect(() => triggerFocus(findDomNode(renderedInstance)!), throwsArgumentError);
       expect(flag, isFalse);
     });
   });

--- a/test/over_react_test/dom_util_test.dart
+++ b/test/over_react_test/dom_util_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 import 'dart:html';
 
 import 'package:over_react/over_react.dart';
@@ -7,21 +8,21 @@ part 'sample_component.over_react.g.dart';
 UiFactory<SampleProps> Sample = castUiFactory(_$Sample); // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
-  bool shouldNeverBeNull;
+  late bool shouldNeverBeNull;
 
-  bool shouldAlwaysBeFalse;
+  late bool shouldAlwaysBeFalse;
 
-  bool shouldErrorInRender;
+  late bool shouldErrorInRender;
 
-  bool shouldErrorInMount;
+  late bool shouldErrorInMount;
 
-  bool shouldErrorInUnmount;
+  late bool shouldErrorInUnmount;
 
-  bool addExtraLogAndWarn;
+  late bool addExtraLogAndWarn;
 
-  Function() onComponentDidMount;
+  Function()? onComponentDidMount;
 
-  bool shouldLog;
+  late bool shouldLog;
 }
 
 class SampleComponent extends UiComponent2<SampleProps> {

--- a/test/over_react_test/helper_components/sample_component.dart
+++ b/test/over_react_test/helper_components/sample_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 import 'dart:html';
 
 import 'package:over_react/over_react.dart';

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 import 'dart:html';
 
 import 'package:over_react/over_react.dart';
@@ -7,7 +8,7 @@ part 'sample_component2.over_react.g.dart';
 UiFactory<Sample2Props> Sample2 = castUiFactory(_$Sample2); // ignore: undefined_identifier
 
 mixin Sample2Props on UiProps {
-  bool shouldNeverBeNull;
+  late bool shouldNeverBeNull;
 }
 
 class SampleComponent2 extends UiComponent2<Sample2Props> {

--- a/test/over_react_test/helper_components/sample_component2.dart
+++ b/test/over_react_test/helper_components/sample_component2.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 import 'dart:html';
 
 import 'package:over_react/over_react.dart';

--- a/test/over_react_test/helper_components/sample_function_component.dart
+++ b/test/over_react_test/helper_components/sample_function_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/helper_components/sample_function_component.dart
+++ b/test/over_react_test/helper_components/sample_function_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -27,14 +27,14 @@ main() {
   group('mount: renders the given instance', () {
     group('attached to the document', () {
       group('and unmounts after the test is done', () {
-        TestJacket jacket;
+        /*late*/TestJacket jacket;
 
         setUp(() {
-          expect(document.body.children, isEmpty);
+          expect(document.body/*!*/.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body.children, isEmpty);
+          expect(document.body/*!*/.children, isEmpty);
           expect(jacket.isMounted, isFalse);
 
           jacket = null;
@@ -44,34 +44,34 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
-          expect(document.body.children[0], mountNode);
-          expect(jacket.isMounted, isTrue);
-          expect(mountNode.children[0], jacket.getNode());
+          expect(document.body/*!*/.children[0], mountNode);
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(mountNode.children[0], jacket/*!*/.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket.isMounted, isTrue);
-          expect(document.body.children[0].children[0], jacket.getNode());
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(document.body/*!*/.children[0].children[0], jacket/*!*/.getNode());
         });
       });
 
       group('and does not unmount after the test is done', () {
-        TestJacket jacket;
+        /*late*/TestJacket/*!*/ jacket;
 
         setUp(() {
-          expect(document.body.children, isEmpty);
+          expect(document.body/*!*/.children, isEmpty);
         });
 
         tearDown(() {
           expect(document.body.children, isNotEmpty);
-          expect(jacket.isMounted, isTrue);
+          expect(jacket/*!*/.isMounted, isTrue);
 
-          jacket.unmount();
+          jacket/*!*/.unmount();
 
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isFalse);
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isFalse);
 
           jacket = null;
         });
@@ -84,32 +84,32 @@ main() {
               autoTearDown: false
           );
 
-          expect(document.body.children[0], mountNode);
-          expect(jacket.isMounted, isTrue);
-          expect(mountNode.children[0], jacket.getNode());
+          expect(document.body/*!*/.children[0], mountNode);
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(mountNode.children[0], jacket/*!*/.getNode());
         });
 
         test('without the given container', () {
           jacket =
               mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
-          expect(jacket.isMounted, isTrue);
-          expect(document.body.children[0].children[0], jacket.getNode());
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(document.body/*!*/.children[0].children[0], jacket/*!*/.getNode());
         });
       });
     });
 
     group('not attached to the document', () {
       group('and unmounts after the test is done', () {
-        TestJacket jacket;
+        /*late*/TestJacket jacket;
 
         setUp(() {
-          expect(document.body.children, isEmpty);
+          expect(document.body/*!*/.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isFalse);
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isFalse);
 
           jacket = null;
         });
@@ -118,33 +118,33 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), mountNode: mountNode);
 
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isTrue);
-          expect(mountNode.children[0], jacket.getNode());
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(mountNode.children[0], jacket/*!*/.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()());
 
-          expect(jacket.isMounted, isTrue);
+          expect(jacket/*!*/.isMounted, isTrue);
         });
       });
 
       group('and does not unmount after the test is done', () {
-        TestJacket jacket;
+        /*late*/TestJacket jacket;
 
         setUp(() {
-          expect(document.body.children, isEmpty);
+          expect(document.body/*!*/.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isTrue);
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isTrue);
 
-          jacket.unmount();
+          jacket/*!*/.unmount();
 
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isFalse);
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isFalse);
 
           jacket = null;
         });
@@ -153,16 +153,16 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), mountNode: mountNode, autoTearDown: false);
 
-          expect(document.body.children.isEmpty, isTrue);
-          expect(jacket.isMounted, isTrue);
-          expect(mountNode.children[0], jacket.getNode());
+          expect(document.body/*!*/.children.isEmpty, isTrue);
+          expect(jacket/*!*/.isMounted, isTrue);
+          expect(mountNode.children[0], jacket/*!*/.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), autoTearDown: false);
 
-          expect(document.body.children, isEmpty);
-          expect(jacket.isMounted, isTrue);
+          expect(document.body/*!*/.children, isEmpty);
+          expect(jacket/*!*/.isMounted, isTrue);
         });
       });
     });
@@ -179,7 +179,7 @@ main() {
       );
 
       expect(Sample(jacket.getProps()).foo, isFalse);
-      expect(jacket.getDartInstance().state.bar, isFalse);
+      expect(jacket.getDartInstance()/*!*/.state.bar, isFalse);
     });
 
     test('rerender', () {
@@ -201,9 +201,9 @@ main() {
     });
 
     test('setState', () {
-      jacket.setState(jacket.getDartInstance().newState()..bar = true);
+      jacket.setState(jacket.getDartInstance()/*!*/.newState()..bar = true);
 
-      expect(jacket.getDartInstance().state.bar, isTrue);
+      expect(jacket.getDartInstance()/*!*/.state.bar, isTrue);
     });
 
     test('unmount', () {
@@ -216,7 +216,7 @@ main() {
   });
 
   group('TestJacket: DOM component:', () {
-    Element mountNode;
+    /*late*/Element mountNode;
     TestJacket jacket;
 
     setUp(() {
@@ -266,7 +266,7 @@ main() {
   });
 
   group('TestJacket: function component:', () {
-    Element mountNode;
+    /*late*/Element mountNode;
     TestJacket jacket;
 
     setUp(() {
@@ -276,18 +276,18 @@ main() {
         attachedToDocument: true
       );
 
-      expect(mountNode.children.single.id, 'foo');
+      expect(mountNode/*!*/.children.single.id, 'foo');
     });
 
     tearDown(() {
-      mountNode.remove();
+      mountNode/*!*/.remove();
       mountNode = null;
     });
 
     test('rerender', () {
       jacket.rerender(testFunctionComponent({'id': 'bar'}));
 
-      expect(mountNode.children.single.id, 'bar');
+      expect(mountNode/*!*/.children.single.id, 'bar');
     });
 
     test('getProps throws a StateError', () {

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -27,15 +27,15 @@ main() {
   group('mount: renders the given instance', () {
     group('attached to the document', () {
       group('and unmounts after the test is done', () {
-        /*late*/TestJacket jacket;
+        late TestJacket? jacket;
 
         setUp(() {
-          expect(document.body/*!*/.children, isEmpty);
+          expect(document.body!.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket.isMounted, isFalse);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isFalse);
 
           jacket = null;
         });
@@ -44,34 +44,34 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
-          expect(document.body/*!*/.children[0], mountNode);
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(mountNode.children[0], jacket/*!*/.getNode());
+          expect(document.body!.children[0], mountNode);
+          expect(jacket!.isMounted, isTrue);
+          expect(mountNode.children[0], jacket!.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(document.body/*!*/.children[0].children[0], jacket/*!*/.getNode());
+          expect(jacket!.isMounted, isTrue);
+          expect(document.body!.children[0].children[0], jacket!.getNode());
         });
       });
 
       group('and does not unmount after the test is done', () {
-        /*late*/TestJacket/*!*/ jacket;
+        late TestJacket jacket;
 
         setUp(() {
-          expect(document.body/*!*/.children, isEmpty);
+          expect(document.body!.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body.children, isNotEmpty);
-          expect(jacket/*!*/.isMounted, isTrue);
+          expect(document.body!.children, isNotEmpty);
+          expect(jacket!.isMounted, isTrue);
 
-          jacket/*!*/.unmount();
+          jacket!.unmount();
 
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isFalse);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isFalse);
 
           jacket = null;
         });
@@ -84,32 +84,32 @@ main() {
               autoTearDown: false
           );
 
-          expect(document.body/*!*/.children[0], mountNode);
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(mountNode.children[0], jacket/*!*/.getNode());
+          expect(document.body!.children[0], mountNode);
+          expect(jacket!.isMounted, isTrue);
+          expect(mountNode.children[0], jacket!.getNode());
         });
 
         test('without the given container', () {
           jacket =
               mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(document.body/*!*/.children[0].children[0], jacket/*!*/.getNode());
+          expect(jacket!.isMounted, isTrue);
+          expect(document.body!.children[0].children[0], jacket!.getNode());
         });
       });
     });
 
     group('not attached to the document', () {
       group('and unmounts after the test is done', () {
-        /*late*/TestJacket jacket;
+        late TestJacket? jacket;
 
         setUp(() {
-          expect(document.body/*!*/.children, isEmpty);
+          expect(document.body!.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isFalse);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isFalse);
 
           jacket = null;
         });
@@ -118,33 +118,33 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), mountNode: mountNode);
 
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(mountNode.children[0], jacket/*!*/.getNode());
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isTrue);
+          expect(mountNode.children[0], jacket!.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()());
 
-          expect(jacket/*!*/.isMounted, isTrue);
+          expect(jacket!.isMounted, isTrue);
         });
       });
 
       group('and does not unmount after the test is done', () {
-        /*late*/TestJacket jacket;
+        late TestJacket? jacket;
 
         setUp(() {
-          expect(document.body/*!*/.children, isEmpty);
+          expect(document.body!.children, isEmpty);
         });
 
         tearDown(() {
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isTrue);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isTrue);
 
-          jacket/*!*/.unmount();
+          jacket!.unmount();
 
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isFalse);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isFalse);
 
           jacket = null;
         });
@@ -153,23 +153,23 @@ main() {
           var mountNode = DivElement();
           jacket = mount(Sample()(), mountNode: mountNode, autoTearDown: false);
 
-          expect(document.body/*!*/.children.isEmpty, isTrue);
-          expect(jacket/*!*/.isMounted, isTrue);
-          expect(mountNode.children[0], jacket/*!*/.getNode());
+          expect(document.body!.children.isEmpty, isTrue);
+          expect(jacket!.isMounted, isTrue);
+          expect(mountNode.children[0], jacket!.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), autoTearDown: false);
 
-          expect(document.body/*!*/.children, isEmpty);
-          expect(jacket/*!*/.isMounted, isTrue);
+          expect(document.body!.children, isEmpty);
+          expect(jacket!.isMounted, isTrue);
         });
       });
     });
   });
 
   group('TestJacket: composite component:', () {
-    TestJacket<SampleComponent> jacket;
+    late TestJacket<SampleComponent> jacket;
 
     setUp(() {
       var mountNode = DivElement();
@@ -179,7 +179,7 @@ main() {
       );
 
       expect(Sample(jacket.getProps()).foo, isFalse);
-      expect(jacket.getDartInstance()/*!*/.state.bar, isFalse);
+      expect(jacket.getDartInstance()!.state.bar, isFalse);
     });
 
     test('rerender', () {
@@ -201,9 +201,9 @@ main() {
     });
 
     test('setState', () {
-      jacket.setState(jacket.getDartInstance()/*!*/.newState()..bar = true);
+      jacket.setState(jacket.getDartInstance()!.newState()..bar = true);
 
-      expect(jacket.getDartInstance()/*!*/.state.bar, isTrue);
+      expect(jacket.getDartInstance()!.state.bar, isTrue);
     });
 
     test('unmount', () {
@@ -216,8 +216,8 @@ main() {
   });
 
   group('TestJacket: DOM component:', () {
-    /*late*/Element mountNode;
-    TestJacket jacket;
+    late Element? mountNode;
+    late TestJacket jacket;
 
     setUp(() {
       mountNode = DivElement();
@@ -226,18 +226,18 @@ main() {
         attachedToDocument: true
       );
 
-      expect(mountNode.children.single, isA<SpanElement>());
+      expect(mountNode!.children.single, isA<SpanElement>());
     });
 
     tearDown(() {
-      mountNode.remove();
+      mountNode!.remove();
       mountNode = null;
     });
 
     test('rerender', () {
       jacket.rerender((Dom.span()..id = 'foo')());
 
-      expect(mountNode.children.single.id, 'foo');
+      expect(mountNode!.children.single.id, 'foo');
     });
 
     test('getProps throws a StateError', () {
@@ -245,7 +245,7 @@ main() {
     });
 
     test('getNode', () {
-      expect(jacket.getNode(), mountNode.children.single);
+      expect(jacket.getNode(), mountNode!.children.single);
     });
 
     test('getDartInstance returns null', () {
@@ -266,8 +266,8 @@ main() {
   });
 
   group('TestJacket: function component:', () {
-    /*late*/Element mountNode;
-    TestJacket jacket;
+    late Element? mountNode;
+    late TestJacket jacket;
 
     setUp(() {
       mountNode = DivElement();
@@ -276,18 +276,18 @@ main() {
         attachedToDocument: true
       );
 
-      expect(mountNode/*!*/.children.single.id, 'foo');
+      expect(mountNode!.children.single.id, 'foo');
     });
 
     tearDown(() {
-      mountNode/*!*/.remove();
+      mountNode!.remove();
       mountNode = null;
     });
 
     test('rerender', () {
       jacket.rerender(testFunctionComponent({'id': 'bar'}));
 
-      expect(mountNode/*!*/.children.single.id, 'bar');
+      expect(mountNode!.children.single.id, 'bar');
     });
 
     test('getProps throws a StateError', () {

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +28,7 @@ main() {
   group('mount: renders the given instance', () {
     group('attached to the document', () {
       group('and unmounts after the test is done', () {
-        late TestJacket? jacket;
+        late TestJacket jacket;
 
         setUp(() {
           expect(document.body!.children, isEmpty);
@@ -35,9 +36,8 @@ main() {
 
         tearDown(() {
           expect(document.body!.children, isEmpty);
-          expect(jacket!.isMounted, isFalse);
+          expect(jacket.isMounted, isFalse);
 
-          jacket = null;
         });
 
         test('with the given container', () {
@@ -45,15 +45,15 @@ main() {
           jacket = mount(Sample()(), attachedToDocument: true, mountNode: mountNode);
 
           expect(document.body!.children[0], mountNode);
-          expect(jacket!.isMounted, isTrue);
-          expect(mountNode.children[0], jacket!.getNode());
+          expect(jacket.isMounted, isTrue);
+          expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()(), attachedToDocument: true);
 
-          expect(jacket!.isMounted, isTrue);
-          expect(document.body!.children[0].children[0], jacket!.getNode());
+          expect(jacket.isMounted, isTrue);
+          expect(document.body!.children[0].children[0], jacket.getNode());
         });
       });
 
@@ -66,14 +66,13 @@ main() {
 
         tearDown(() {
           expect(document.body!.children, isNotEmpty);
-          expect(jacket!.isMounted, isTrue);
+          expect(jacket.isMounted, isTrue);
 
-          jacket!.unmount();
+          jacket.unmount();
 
           expect(document.body!.children, isEmpty);
-          expect(jacket!.isMounted, isFalse);
+          expect(jacket.isMounted, isFalse);
 
-          jacket = null;
         });
 
         test('with the given container', () {
@@ -85,23 +84,23 @@ main() {
           );
 
           expect(document.body!.children[0], mountNode);
-          expect(jacket!.isMounted, isTrue);
-          expect(mountNode.children[0], jacket!.getNode());
+          expect(jacket.isMounted, isTrue);
+          expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket =
               mount(Sample()(), attachedToDocument: true, autoTearDown: false);
 
-          expect(jacket!.isMounted, isTrue);
-          expect(document.body!.children[0].children[0], jacket!.getNode());
+          expect(jacket.isMounted, isTrue);
+          expect(document.body!.children[0].children[0], jacket.getNode());
         });
       });
     });
 
     group('not attached to the document', () {
       group('and unmounts after the test is done', () {
-        late TestJacket? jacket;
+        late TestJacket jacket;
 
         setUp(() {
           expect(document.body!.children, isEmpty);
@@ -109,9 +108,7 @@ main() {
 
         tearDown(() {
           expect(document.body!.children, isEmpty);
-          expect(jacket!.isMounted, isFalse);
-
-          jacket = null;
+          expect(jacket.isMounted, isFalse);
         });
 
         test('with the given container', () {
@@ -119,14 +116,14 @@ main() {
           jacket = mount(Sample()(), mountNode: mountNode);
 
           expect(document.body!.children, isEmpty);
-          expect(jacket!.isMounted, isTrue);
-          expect(mountNode.children[0], jacket!.getNode());
+          expect(jacket.isMounted, isTrue);
+          expect(mountNode.children[0], jacket.getNode());
         });
 
         test('without the given container', () {
           jacket = mount(Sample()());
 
-          expect(jacket!.isMounted, isTrue);
+          expect(jacket.isMounted, isTrue);
         });
       });
 
@@ -216,7 +213,7 @@ main() {
   });
 
   group('TestJacket: DOM component:', () {
-    late Element? mountNode;
+    late Element mountNode;
     late TestJacket jacket;
 
     setUp(() {
@@ -226,18 +223,17 @@ main() {
         attachedToDocument: true
       );
 
-      expect(mountNode!.children.single, isA<SpanElement>());
+      expect(mountNode.children.single, isA<SpanElement>());
     });
 
     tearDown(() {
-      mountNode!.remove();
-      mountNode = null;
+      mountNode.remove();
     });
 
     test('rerender', () {
       jacket.rerender((Dom.span()..id = 'foo')());
 
-      expect(mountNode!.children.single.id, 'foo');
+      expect(mountNode.children.single.id, 'foo');
     });
 
     test('getProps throws a StateError', () {
@@ -245,7 +241,7 @@ main() {
     });
 
     test('getNode', () {
-      expect(jacket.getNode(), mountNode!.children.single);
+      expect(jacket.getNode(), mountNode.children.single);
     });
 
     test('getDartInstance returns null', () {
@@ -266,7 +262,7 @@ main() {
   });
 
   group('TestJacket: function component:', () {
-    late Element? mountNode;
+    late Element mountNode;
     late TestJacket jacket;
 
     setUp(() {
@@ -276,18 +272,17 @@ main() {
         attachedToDocument: true
       );
 
-      expect(mountNode!.children.single.id, 'foo');
+      expect(mountNode.children.single.id, 'foo');
     });
 
     tearDown(() {
-      mountNode!.remove();
-      mountNode = null;
+      mountNode.remove();
     });
 
     test('rerender', () {
       jacket.rerender(testFunctionComponent({'id': 'bar'}));
 
-      expect(mountNode!.children.single.id, 'bar');
+      expect(mountNode.children.single.id, 'bar');
     });
 
     test('getProps throws a StateError', () {
@@ -319,11 +314,11 @@ main() {
 UiFactory<SampleProps> Sample = castUiFactory(_$Sample); // ignore: undefined_identifier
 
 mixin SampleProps on UiProps {
-  bool foo;
+  late bool foo;
 }
 
 mixin SampleState on UiState {
-  bool bar;
+  late bool bar;
 }
 
 class SampleComponent extends UiStatefulComponent2<SampleProps, SampleState> {

--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -59,37 +59,37 @@ main() {
             reason: 'The React instance should have been unmounted.'
         );
 
-        expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
+        expect(document.body/*!*/.children, isEmpty, reason: 'All attached mount points should have been removed.');
       });
 
       test('renderAttachedToDocument renders the component into the document', () {
-        expect(document.body.children, isEmpty);
+        expect(document.body/*!*/.children, isEmpty);
 
         renderedInstance = renderAttachedToDocument(Wrapper());
 
-        expect(document.body.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+        expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
             reason: 'The component should have been rendered into the container div.');
       });
 
       test('renderAttachedToDocument renders the component into the document with a given container', () {
-        expect(document.body.children, isEmpty);
+        expect(document.body/*!*/.children, isEmpty);
 
         var container = DivElement();
         renderedInstance = renderAttachedToDocument(Wrapper(), container: container);
 
-        expect(document.body.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+        expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
             reason: 'The component should have been rendered into the container div.');
-        expect(document.body.children[0], container);
+        expect(document.body/*!*/.children[0], container);
       });
     });
 
 
     test('renderAttachedToDocument renders the component into the document and tearDownAttachedNodes cleans them up', () {
-      expect(document.body.children, isEmpty);
+      expect(document.body/*!*/.children, isEmpty);
 
       var renderedInstance = renderAttachedToDocument(Wrapper(), autoTearDown: false);
 
-      expect(document.body.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+      expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
           reason: 'The component should have been rendered into the container div.');
 
       tearDownAttachedNodes();
@@ -102,7 +102,7 @@ main() {
           reason: 'The React instance should have been unmounted.'
       );
 
-      expect(document.body.children, isEmpty, reason: 'All attached mount points should have been removed.');
+      expect(document.body/*!*/.children, isEmpty, reason: 'All attached mount points should have been removed.');
     });
 
     group('renderAndGetDom', () {
@@ -253,9 +253,9 @@ main() {
     });
 
     group('getByTestId returns', () {
-      sharedTests({bool shallow}) {
+      sharedTests({bool/*?*/ shallow}) {
         testSpecificRender(ReactElement instance) =>
-            shallow ? renderShallow(instance) : render(instance);
+            shallow/*!*/ ? renderShallow(instance) : render(instance);
 
         group('the single descendant that has the appropriate value for the `data-test-id` prop key when it is a', () {
           const String targetFlagProp = 'data-name';
@@ -461,9 +461,9 @@ main() {
     });
 
     group('getAllByTestId returns', () {
-      sharedTests({bool shallow}) {
+      sharedTests({bool/*?*/ shallow}) {
         testSpecificRender(ReactElement instance) =>
-            shallow ? renderShallow(instance) : render(instance);
+            shallow/*!*/ ? renderShallow(instance) : render(instance);
 
         group('a list containing the single descendant that have the appropriate value for the `data-test-id` prop key when it is a', () {
           const String targetFlagProp = 'data-name';
@@ -683,7 +683,7 @@ main() {
     group('getAllComponentsByTestId returns only the Dart components with the matching test ID', () {
       void sharedExpectations(
         List<dynamic> allByTestId,
-        List<WrapperComponent> allComponentsByTestId,
+        List<WrapperComponent/*!*/> allComponentsByTestId,
       ) {
         final isCompositeCOmponentMatcher = predicate(rtu.isCompositeComponent, 'is composite component');
 
@@ -750,7 +750,7 @@ main() {
         group('`data-test-id` html attribute key', () {
           test('', () {
             var renderedInstance = render((Nested()..addTestId('value'))());
-            var innerNode = findDomNode(renderedInstance).querySelector('[data-test-id~="inner"]');
+            var innerNode = findDomNode(renderedInstance)/*!*/.querySelector('[data-test-id~="inner"]');
 
             expect(queryByTestId(renderedInstance, 'value'), innerNode);
           });
@@ -764,7 +764,7 @@ main() {
 
         test('custom html attribute key', () {
           var renderedInstance = render((Nested()..addTestId('value', key: 'data-custom-id'))());
-          var innerNode = findDomNode(renderedInstance).querySelector('[data-test-id~="inner"]');
+          var innerNode = findDomNode(renderedInstance)/*!*/.querySelector('[data-test-id~="inner"]');
 
           expect(queryByTestId(renderedInstance, 'value', key: 'data-custom-id'), innerNode);
         });
@@ -788,7 +788,7 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var innerNode = shadowHostRef.current.shadowRoot.querySelector('[data-test-id~="$searchId"]');
+          var innerNode = shadowHostRef.current/*!*/.shadowRoot/*!*/.querySelector('[data-test-id~="$searchId"]');
 
           expect(queryByTestId(jacket.mountNode, searchId, searchInShadowDom: true), innerNode);
         });
@@ -817,7 +817,7 @@ main() {
               (Nested()..addTestId('value'))(),
               (Nested()..addTestId('value'))(),
             ));
-            var innerNodes = findDomNode(renderedInstance).querySelectorAll('[data-test-id~="inner"]');
+            var innerNodes = findDomNode(renderedInstance)/*!*/.querySelectorAll('[data-test-id~="inner"]');
 
             expect(queryAllByTestId(renderedInstance, 'value'), innerNodes);
           });
@@ -834,7 +834,7 @@ main() {
             (Nested()..addTestId('value'))(),
             (Nested()..addTestId('value'))(),
           ));
-          var innerNodes = findDomNode(renderedInstance).querySelectorAll('[data-test-id~="inner"]');
+          var innerNodes = findDomNode(renderedInstance)/*!*/.querySelectorAll('[data-test-id~="inner"]');
 
           expect(queryAllByTestId(renderedInstance, 'value'), innerNodes);
         });
@@ -878,9 +878,9 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var level1 = shadow1Ref.current.shadowRoot.querySelector('.div1');
-          var level2 = shadow2Ref.current.shadowRoot.querySelector('.div2');
-          var level3 = shadow3Ref.current.shadowRoot.querySelector('.div3');
+          var level1 = shadow1Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div1');
+          var level2 = shadow2Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div2');
+          var level3 = shadow3Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div3');
 
           expect(queryAllByTestId(jacket.mountNode, 'findMe', searchInShadowDom: true), [level1, level2, level3]);
         });
@@ -919,7 +919,7 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var level1 = shadow1Ref.current.shadowRoot.querySelector('.div1');
+          var level1 = shadow1Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div1');
 
           expect(queryAllByTestId(jacket.mountNode, 'findMe', searchInShadowDom: true, shadowDepth: 1), [level1]);
         });

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -59,37 +59,37 @@ main() {
             reason: 'The React instance should have been unmounted.'
         );
 
-        expect(document.body/*!*/.children, isEmpty, reason: 'All attached mount points should have been removed.');
+        expect(document.body!.children, isEmpty, reason: 'All attached mount points should have been removed.');
       });
 
       test('renderAttachedToDocument renders the component into the document', () {
-        expect(document.body/*!*/.children, isEmpty);
+        expect(document.body!.children, isEmpty);
 
         renderedInstance = renderAttachedToDocument(Wrapper());
 
-        expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+        expect(document.body!.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
             reason: 'The component should have been rendered into the container div.');
       });
 
       test('renderAttachedToDocument renders the component into the document with a given container', () {
-        expect(document.body/*!*/.children, isEmpty);
+        expect(document.body!.children, isEmpty);
 
         var container = DivElement();
         renderedInstance = renderAttachedToDocument(Wrapper(), container: container);
 
-        expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+        expect(document.body!.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
             reason: 'The component should have been rendered into the container div.');
-        expect(document.body/*!*/.children[0], container);
+        expect(document.body!.children[0], container);
       });
     });
 
 
     test('renderAttachedToDocument renders the component into the document and tearDownAttachedNodes cleans them up', () {
-      expect(document.body/*!*/.children, isEmpty);
+      expect(document.body!.children, isEmpty);
 
       var renderedInstance = renderAttachedToDocument(Wrapper(), autoTearDown: false);
 
-      expect(document.body/*!*/.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
+      expect(document.body!.children[0].children.contains(findDomNode(renderedInstance)), isTrue,
           reason: 'The component should have been rendered into the container div.');
 
       tearDownAttachedNodes();
@@ -102,7 +102,7 @@ main() {
           reason: 'The React instance should have been unmounted.'
       );
 
-      expect(document.body/*!*/.children, isEmpty, reason: 'All attached mount points should have been removed.');
+      expect(document.body!.children, isEmpty, reason: 'All attached mount points should have been removed.');
     });
 
     group('renderAndGetDom', () {
@@ -145,7 +145,7 @@ main() {
 
       test('simulates a click on a component with additional event data', () {
         var flag = false;
-        SyntheticMouseEvent event;
+        late SyntheticMouseEvent event;
         var renderedInstance = render((Dom.div()
           ..onClick = (evt) {
             flag = true;
@@ -253,9 +253,9 @@ main() {
     });
 
     group('getByTestId returns', () {
-      sharedTests({bool/*?*/ shallow}) {
+      sharedTests({bool? shallow}) {
         testSpecificRender(ReactElement instance) =>
-            shallow/*!*/ ? renderShallow(instance) : render(instance);
+            shallow! ? renderShallow(instance) : render(instance);
 
         group('the single descendant that has the appropriate value for the `data-test-id` prop key when it is a', () {
           const String targetFlagProp = 'data-name';
@@ -461,9 +461,9 @@ main() {
     });
 
     group('getAllByTestId returns', () {
-      sharedTests({bool/*?*/ shallow}) {
+      sharedTests({bool? shallow}) {
         testSpecificRender(ReactElement instance) =>
-            shallow/*!*/ ? renderShallow(instance) : render(instance);
+            shallow! ? renderShallow(instance) : render(instance);
 
         group('a list containing the single descendant that have the appropriate value for the `data-test-id` prop key when it is a', () {
           const String targetFlagProp = 'data-name';
@@ -683,7 +683,7 @@ main() {
     group('getAllComponentsByTestId returns only the Dart components with the matching test ID', () {
       void sharedExpectations(
         List<dynamic> allByTestId,
-        List<WrapperComponent/*!*/> allComponentsByTestId,
+        List<WrapperComponent> allComponentsByTestId,
       ) {
         final isCompositeCOmponentMatcher = predicate(rtu.isCompositeComponent, 'is composite component');
 
@@ -750,7 +750,7 @@ main() {
         group('`data-test-id` html attribute key', () {
           test('', () {
             var renderedInstance = render((Nested()..addTestId('value'))());
-            var innerNode = findDomNode(renderedInstance)/*!*/.querySelector('[data-test-id~="inner"]');
+            var innerNode = findDomNode(renderedInstance)!.querySelector('[data-test-id~="inner"]');
 
             expect(queryByTestId(renderedInstance, 'value'), innerNode);
           });
@@ -764,7 +764,7 @@ main() {
 
         test('custom html attribute key', () {
           var renderedInstance = render((Nested()..addTestId('value', key: 'data-custom-id'))());
-          var innerNode = findDomNode(renderedInstance)/*!*/.querySelector('[data-test-id~="inner"]');
+          var innerNode = findDomNode(renderedInstance)!.querySelector('[data-test-id~="inner"]');
 
           expect(queryByTestId(renderedInstance, 'value', key: 'data-custom-id'), innerNode);
         });
@@ -788,7 +788,7 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var innerNode = shadowHostRef.current/*!*/.shadowRoot/*!*/.querySelector('[data-test-id~="$searchId"]');
+          var innerNode = shadowHostRef.current!.shadowRoot!.querySelector('[data-test-id~="$searchId"]');
 
           expect(queryByTestId(jacket.mountNode, searchId, searchInShadowDom: true), innerNode);
         });
@@ -817,7 +817,7 @@ main() {
               (Nested()..addTestId('value'))(),
               (Nested()..addTestId('value'))(),
             ));
-            var innerNodes = findDomNode(renderedInstance)/*!*/.querySelectorAll('[data-test-id~="inner"]');
+            var innerNodes = findDomNode(renderedInstance)!.querySelectorAll('[data-test-id~="inner"]');
 
             expect(queryAllByTestId(renderedInstance, 'value'), innerNodes);
           });
@@ -834,7 +834,7 @@ main() {
             (Nested()..addTestId('value'))(),
             (Nested()..addTestId('value'))(),
           ));
-          var innerNodes = findDomNode(renderedInstance)/*!*/.querySelectorAll('[data-test-id~="inner"]');
+          var innerNodes = findDomNode(renderedInstance)!.querySelectorAll('[data-test-id~="inner"]');
 
           expect(queryAllByTestId(renderedInstance, 'value'), innerNodes);
         });
@@ -878,9 +878,9 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var level1 = shadow1Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div1');
-          var level2 = shadow2Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div2');
-          var level3 = shadow3Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div3');
+          var level1 = shadow1Ref.current!.shadowRoot!.querySelector('.div1');
+          var level2 = shadow2Ref.current!.shadowRoot!.querySelector('.div2');
+          var level3 = shadow3Ref.current!.shadowRoot!.querySelector('.div3');
 
           expect(queryAllByTestId(jacket.mountNode, 'findMe', searchInShadowDom: true), [level1, level2, level3]);
         });
@@ -919,7 +919,7 @@ main() {
           // Let the shadow dom mount (the test components kinda slow since it does it after adding it to the dom.)
           await pumpEventQueue();
 
-          var level1 = shadow1Ref.current/*!*/.shadowRoot/*!*/.querySelector('.div1');
+          var level1 = shadow1Ref.current!.shadowRoot!.querySelector('.div1');
 
           expect(queryAllByTestId(jacket.mountNode, 'findMe', searchInShadowDom: true, shadowDepth: 1), [level1]);
         });

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/nested_component.dart
+++ b/test/over_react_test/utils/nested_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/shadow_nested_component.dart
+++ b/test/over_react_test/utils/shadow_nested_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/shadow_nested_component.dart
+++ b/test/over_react_test/utils/shadow_nested_component.dart
@@ -30,7 +30,7 @@ UiFactory<ShadowNestedProps> ShadowNested = uiForwardRef(
 
     useEffect(() {
 	      var shadowRootFirstChild = DivElement()..dataset['test-id'] = props.shadowRootFirstChildTestId ?? 'shadowRootFirstChild';
-	      divRef.current.attachShadow({'mode':'open'}).append(shadowRootFirstChild);
+	      divRef.current/*!*/.attachShadow({'mode':'open'}).append(shadowRootFirstChild);
 	      react_dom.render(Fragment()(props.children), shadowRootFirstChild);
 	      return () => react_dom.unmountComponentAtNode(shadowRootFirstChild);
 	    }, []);

--- a/test/over_react_test/utils/shadow_nested_component.dart
+++ b/test/over_react_test/utils/shadow_nested_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +21,8 @@ import 'package:over_react/react_dom.dart' as react_dom;
 part 'shadow_nested_component.over_react.g.dart';
 
 mixin ShadowNestedProps on UiProps {
-  String shadowRootHostTestId;
-  String shadowRootFirstChildTestId;
+  String? shadowRootHostTestId;
+  String? shadowRootFirstChildTestId;
 }
 
 UiFactory<ShadowNestedProps> ShadowNested = uiForwardRef(

--- a/test/over_react_test/utils/shadow_nested_component.dart
+++ b/test/over_react_test/utils/shadow_nested_component.dart
@@ -30,7 +30,7 @@ UiFactory<ShadowNestedProps> ShadowNested = uiForwardRef(
 
     useEffect(() {
 	      var shadowRootFirstChild = DivElement()..dataset['test-id'] = props.shadowRootFirstChildTestId ?? 'shadowRootFirstChild';
-	      divRef.current/*!*/.attachShadow({'mode':'open'}).append(shadowRootFirstChild);
+	      divRef.current!.attachShadow({'mode':'open'}).append(shadowRootFirstChild);
 	      react_dom.render(Fragment()(props.children), shadowRootFirstChild);
 	      return () => react_dom.unmountComponentAtNode(shadowRootFirstChild);
 	    }, []);

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -57,7 +57,7 @@ abstract class PropsThatShouldBeForwarded {
 
   Map get props;
 
-  bool/*?*/ foo;
+  bool? foo;
 }
 
 @PropsMixin()
@@ -69,7 +69,7 @@ abstract class PropsThatShouldNotBeForwarded {
 
   Map get props;
 
-  bool/*?*/ bar;
+  bool? bar;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -57,7 +57,7 @@ abstract class PropsThatShouldBeForwarded {
 
   Map get props;
 
-  bool foo;
+  bool/*?*/ foo;
 }
 
 @PropsMixin()
@@ -69,7 +69,7 @@ abstract class PropsThatShouldNotBeForwarded {
 
   Map get props;
 
-  bool bar;
+  bool/*?*/ bar;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component.dart
+++ b/test/over_react_test/utils/test_common_component.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_nested.dart
+++ b/test/over_react_test/utils/test_common_component_nested.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_nested2.dart
+++ b/test/over_react_test/utils/test_common_component_nested2.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,13 +48,13 @@ class TestCommonForwardingComponent extends UiComponent2<TestCommonForwardingPro
 }
 
 mixin ShouldBeForwardedProps on UiProps {
-  bool foo;
-  bool foo2;
+  bool? foo;
+  bool? foo2;
 }
 
 mixin ShouldNotBeForwardedProps on UiProps {
-  bool bar;
-  Iterable propKeysToForwardAnyways;
+  bool? bar;
+  late Iterable propKeysToForwardAnyways;
 }
 
 UiFactory<TestCommonDomOnlyForwardingProps> TestCommonDomOnlyForwarding =

--- a/test/over_react_test/utils/test_common_component_new_boilerplate.dart
+++ b/test/over_react_test/utils/test_common_component_new_boilerplate.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -23,13 +23,13 @@ UiFactory<TestCommonRequiredProps> TestCommonRequired =
 @Props()
 class _$TestCommonRequiredProps extends UiProps {
   @nullableRequiredProp
-  bool/*?*/ foobar;
+  bool? foobar;
 
   @requiredProp
-  bool/*?*/ bar;
+  bool? bar;
 
   @nullableRequiredProp
-  bool/*?*/ defaultFoo;
+  bool? defaultFoo;
 }
 
 @Component()

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -23,13 +23,13 @@ UiFactory<TestCommonRequiredProps> TestCommonRequired =
 @Props()
 class _$TestCommonRequiredProps extends UiProps {
   @nullableRequiredProp
-  bool foobar;
+  bool/*?*/ foobar;
 
   @requiredProp
-  bool bar;
+  bool/*?*/ bar;
 
   @nullableRequiredProp
-  bool defaultFoo;
+  bool/*?*/ defaultFoo;
 }
 
 @Component()

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_required_props.dart
+++ b/test/over_react_test/utils/test_common_component_required_props.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,13 +22,13 @@ UiFactory<TestCommonRequired2Props> TestCommonRequired2 =
 
 mixin TestCommonRequired2Props on UiProps {
   @nullableRequiredProp
-  bool foobar;
+  bool? foobar;
 
   @requiredProp
-  bool bar;
+  bool? bar;
 
   @nullableRequiredProp
-  bool defaultFoo;
+  bool? defaultFoo;
 }
 
 class TestCommonRequired2Component extends

--- a/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
+++ b/test/over_react_test/utils/test_common_component_required_props_commponent2.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -34,7 +34,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings().single, 'message1');
+        expect(getValidationWarnings()/*!*/.single, 'message1');
 
         assert(ValidationUtil.warn('message2'));
 
@@ -48,7 +48,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings().single, 'message1');
+        expect(getValidationWarnings()/*!*/.single, 'message1');
 
         stopRecordingValidationWarnings();
 
@@ -94,7 +94,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings().single, 'message1');
+        expect(getValidationWarnings()/*!*/.single, 'message1');
 
         clearValidationWarnings();
 
@@ -103,7 +103,7 @@ main() {
         assert(ValidationUtil.warn('message2'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings().single, 'message2');
+        expect(getValidationWarnings()/*!*/.single, 'message2');
       });
     });
   }, testOn: '!js');

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -34,7 +34,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings()/*!*/.single, 'message1');
+        expect(getValidationWarnings()!.single, 'message1');
 
         assert(ValidationUtil.warn('message2'));
 
@@ -48,7 +48,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings()/*!*/.single, 'message1');
+        expect(getValidationWarnings()!.single, 'message1');
 
         stopRecordingValidationWarnings();
 
@@ -94,7 +94,7 @@ main() {
         assert(ValidationUtil.warn('message1'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings()/*!*/.single, 'message1');
+        expect(getValidationWarnings()!.single, 'message1');
 
         clearValidationWarnings();
 
@@ -103,7 +103,7 @@ main() {
         assert(ValidationUtil.warn('message2'));
 
         expect(getValidationWarnings(), hasLength(1));
-        expect(getValidationWarnings()/*!*/.single, 'message2');
+        expect(getValidationWarnings()!.single, 'message2');
       });
     });
   }, testOn: '!js');

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/validation_util_test.dart
+++ b/test/over_react_test/validation_util_test.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -9,7 +9,7 @@ import 'helper_components/sample_component.dart';
 
 main() {
   group('TestJacket mount', () {
-    sharedZoneRenderTests(mount);
+    sharedZoneRenderTests(mount as dynamic Function(ReactElement, {bool? autoTearDown}));
   });
 
   group('render', () {
@@ -21,7 +21,7 @@ main() {
   });
 }
 
-void sharedZoneRenderTests(Function(ReactElement element, {bool/*?*/ autoTearDown}) renderFunction) {
+void sharedZoneRenderTests(Function(ReactElement element, {bool? autoTearDown}) renderFunction) {
   group('sharedZoneRenderTests:', () {
     setUp(() {
       setComponentZone(Zone.root);

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -1,3 +1,4 @@
+// @dart = 2.14
 import 'dart:async';
 
 import 'package:over_react_test/over_react_test.dart';

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -21,7 +21,7 @@ main() {
   });
 }
 
-void sharedZoneRenderTests(Function(ReactElement element, {bool autoTearDown}) renderFunction) {
+void sharedZoneRenderTests(Function(ReactElement element, {bool/*?*/ autoTearDown}) renderFunction) {
   group('sharedZoneRenderTests:', () {
     setUp(() {
       setComponentZone(Zone.root);

--- a/test/over_react_test/zone_render_tests.dart
+++ b/test/over_react_test/zone_render_tests.dart
@@ -1,4 +1,4 @@
-// @dart = 2.14
+// @dart = 2.12
 import 'dart:async';
 
 import 'package:over_react_test/over_react_test.dart';


### PR DESCRIPTION
## Motivation
We need to migrate to null safety for the dart 3 migration so let's do that.

## Changes
Run the migration tool and migrate to null safety

#### Release Notes
- Migrate to null safety

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
