### PR TITLE
Add workiva_dependency_constrainer

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, dev ]
+        sdk: [ 2.18.7, 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable ]
+        sdk: [ 2.18.7, 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.13 as dart2
+FROM dart:2.18 as dart2
 # Build Environment Vars
 ARG BUILD_ID
 ARG BUILD_NUMBER

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   js: ^0.6.1+1
   matcher: ^0.12.1+4
-  meta: '>=1.6.0  <1.10.0'
+  meta: ^1.8.0
   over_react: ^4.1.2
   react: ^6.0.1
   test: ^1.15.7
@@ -18,6 +18,11 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
   pedantic: ^1.8.0
+  workiva_dependency_constrainer:
+    hosted:
+      name: workiva_dependency_constrainer
+      url: https://pub.workiva.org
+    version: ^1.0.0
 dependency_validator:
   ignore:
-    - meta
+    - workiva_dependency_constrainer


### PR DESCRIPTION
# Summary
In order to make the upgrade to analyzer 5 more predictable,
Frontend Frameworks is adding a dev dependency on a new package
`workiva_dependency_constrainer` which constrains analyzer to ^2,
mockito to `'>=5.0.0 <5.3.0'` and meta to `'>=1.6.0 <1.10.0'`

Once analyzer 5 ready packages for over_react, dart_storybook,
puppeteer_platform, and json_serializable_3_5_2 are released
and tested, then a newer version of the constrainer will be
released to unpin analyzer and mockito. This will prevent
repos from upgrading in an unpredictable order or time and
keeps things how they are until we're all ready to upgrade at
the same time.

As part of this batch, the pin on mockito and meta in this repo
will be removed, since they are now handled by the constrainer.
The extra dependency validator ignores on meta and mockito are
also removed.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/add_wdc`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/add_wdc)