### PR TITLE
FED-1852 Remove usages of deprecated APIs to be removed in react-dart 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Test Changelog
 
+## 2.11.6
+* Remove usages of deprecated APIs that will be removed in react-dart 7.0.0
+* Bump dependencies: `meta: ^1.8.0`, `test: ^1.21.1`
+
 ## 2.11.5
 * Unpin meta dependency
 

--- a/lib/src/over_react_test/js_component.dart
+++ b/lib/src/over_react_test/js_component.dart
@@ -25,9 +25,8 @@ final Function testJsComponentFactory = (() {
     render: allowInterop(() => react.div({}, 'test js component'))
   ));
 
-  var reactFactory = React.createFactory(componentClass);
-
   return ([props = const {}, children]) {
-    return reactFactory(jsifyAndAllowInterop(props), listifyChildren(children));
+    return React.createElement(
+        componentClass, jsifyAndAllowInterop(props), listifyChildren(children));
   };
 })();


### PR DESCRIPTION
## Motivation
react-dart 7.0.0 will remove some APIs, including `React.createFactory` which is used in this package.

Let's address this usage ahead of time to enable easier consumer testing of that major. 

## Changes
- Remove usage of deprecated `React.createFactory`.
- Update changelog so that it's ready to go when we trigger a release after merging this PR

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
