### PR TITLE
Allow react 7 and w_flux 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   matcher: ^0.12.1+4
   meta: ^1.8.0
   over_react: ^4.1.2
-  react: ^6.0.1
+  react: '>=6.0.1 <8.0.0'
   test: ^1.21.1
 dev_dependencies:
   build_runner: ^2.1.2


### PR DESCRIPTION
This PR raises the max allowed versions for react and w_flux. A second batch will follow to raise the minimums of these later.
These versions have been tested across the frontend ecosystem in a test batch prior to releasing these versions.
Feel free to review, approve and merge if CI passes. Otherwise someone on FEDX will come around and get it merged.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_flux_majors`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/react_flux_majors)