### PR TITLE
Add regression tests for container styles

### DIFF
--- a/test/over_react_test/jacket_test.dart
+++ b/test/over_react_test/jacket_test.dart
@@ -135,6 +135,26 @@ main() {
         });
       });
     });
+
+    test('uses an 800px by 800px mountNode when none is provided', () {
+      final jacket = mount(Sample()());
+      expect(jacket.mountNode.style.width, '800px');
+      expect(jacket.mountNode.style.height, '800px');
+    });
+
+    test('does not mutate the styles (including width/height) of the provided mountNode', () {
+      final mountNode = DivElement()
+        ..style.width = '123px'
+        ..style.height = '456px';
+      final initialMountNodeCssText = mountNode.style.cssText;
+
+      final jacket = mount(Sample()(), mountNode: mountNode);
+      expect(jacket.mountNode, mountNode, reason: 'test setup check');
+
+      expect(mountNode.style.width, '123px');
+      expect(mountNode.style.height, '456px');
+      expect(mountNode.style.cssText, initialMountNodeCssText);
+    });
   });
 
   group('TestJacket: composite component:', () {

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -105,6 +105,27 @@ main() {
       expect(document.body!.children, isEmpty, reason: 'All attached mount points should have been removed.');
     });
 
+    test('renderAttachedToDocument uses a 800px/800px container when none is provided', () {
+      final renderedInstance = renderAttachedToDocument(Wrapper());
+      final container = findDomNode(renderedInstance)!.parent!;
+      expect(container.style.width, '800px');
+      expect(container.style.height, '800px');
+    });
+
+    test('renderAttachedToDocument does not mutate the styles (including width/height) of the provided container', () {
+      var container = DivElement()
+        ..style.width = '123px'
+        ..style.height = '456px';
+      final initialContainerCssText = container.style.cssText;
+
+      final renderedInstance = renderAttachedToDocument(Wrapper(), container: container);
+      expect(findDomNode(renderedInstance)!.parent!, container, reason: 'test setup check');
+
+      expect(container.style.width, '123px');
+      expect(container.style.height, '456px');
+      expect(container.style.cssText, initialContainerCssText);
+    });
+
     group('renderAndGetDom', () {
       test('renders and returns the root node of a composite component', () {
         expect(renderAndGetDom(Test()()), isA<Element>());


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
