### PR TITLE
FED-2451 Make root args to query(All)ByTestId nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 3.0.0
 * Add support for Dart null safety ([#155](https://github.com/Workiva/over_react_test/pull/155))
-  * **BREAKING CHANGES**
-    *  The first argument of `queryByTestId` / `queryAllByTestId` (`root`) is now non-nullable ([#157](https://github.com/Workiva/over_react_test/pull/157)).
   * SDK / Dependency Versioning:
     * Increase minimum Dart SDK version from `2.11.0` to `2.13.0`.
     * Increase minimum `react` version from `6.0.1` to `7.0.0`.

--- a/lib/src/over_react_test/react_util.dart
+++ b/lib/src/over_react_test/react_util.dart
@@ -422,6 +422,9 @@ Element? getComponentRootDomByTestId(dynamic root, String value, {String key = d
 /// Returns the [Element] of the first descendant of [root] that has its [key] html attribute value set to a
 /// space-delimited string containing [value].
 ///
+/// Throws if [root] or `findDomNode(root)` is `null`. [root] is kept nullable for convenience, since the input
+/// to this function is often a `dynamic` component instance value.
+///
 /// Setting [searchInShadowDom] to true will allow the query to search within ShadowRoots that use `mode:"open"`.
 /// [shadowDepth] will limit how many layers of ShadowDOM will searched. By default it will search infinitely deep, and this
 /// should only be needed if there are a lot of ShadowRoots within ShadowRoots.
@@ -450,7 +453,7 @@ Element? getComponentRootDomByTestId(dynamic root, String value, {String key = d
 ///     queryByTestId(renderedInstance, 'value'); // returns the `inner` `<div>`
 ///
 /// Related: [queryAllByTestId], [getComponentRootDomByTestId].
-Element? queryByTestId(Object root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
+Element? queryByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
   ArgumentError.checkNotNull(root, 'root');
 
   final node = findDomNode(root);
@@ -463,6 +466,9 @@ Element? queryByTestId(Object root, String value, {String key = defaultTestIdKey
 }
 
 /// Returns all descendant [Element]s of [root] that has their [key] html attribute value set to [value].
+///
+/// Throws if [root] or `findDomNode(root)` is `null`. [root] is kept nullable for convenience, since the input
+/// to this function is often a `dynamic` component instance value.
 ///
 /// Setting [searchInShadowDom] to true will allow the query to search within ShadowRoots that use `mode:"open"`.
 /// [shadowDepth] will limit how many layers of ShadowDOM will searched. By default it will search infinitely deep, and this
@@ -497,7 +503,7 @@ Element? queryByTestId(Object root, String value, {String key = defaultTestIdKey
 ///     </div>
 ///
 ///     queryAllByTestId(renderedInstance, 'value'); // returns both `inner` `<div>`s
-List<Element> queryAllByTestId(Object root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
+List<Element> queryAllByTestId(dynamic root, String value, {String key = defaultTestIdKey, bool searchInShadowDom = false, int? shadowDepth}) {
   ArgumentError.checkNotNull(root, 'root');
 
   final node = findDomNode(root);

--- a/test/over_react_test/react_util_test.dart
+++ b/test/over_react_test/react_util_test.dart
@@ -809,6 +809,10 @@ main() {
         });
       });
 
+      test('throws when root is null', () {
+        expect(() => queryByTestId(null, 'unusedTestId'), throwsA(isA<ArgumentError>()));
+      });
+
       test('throws a helpful error when findDomNode(root) is null', () {
         var jacket = mount(RendersNothing()());
         expect(
@@ -932,6 +936,10 @@ main() {
 
           expect(queryAllByTestId(jacket.mountNode, 'findMe', searchInShadowDom: true, shadowDepth: 1), [level1]);
         });
+      });
+
+      test('throws when root is null', () {
+        expect(() => queryAllByTestId(null, 'unusedTestId'), throwsA(isA<ArgumentError>()));
       });
 
       test('throws a helpful error when findDomNode(root) is null', () {


### PR DESCRIPTION
## Motivation
Having the root arg to `query(All)ByTestId` [be non-nullable](https://github.com/Workiva/over_react_test/pull/157) is inconvenient for consumers who have implicit casts enabled and pass `dynamic` component instances into those functions.

Since any null errors would only occur in tests, we think it's worth going back to making them nullable just to save consumers effort when migrating to null safety.

## Changes
- Make root args to `query(All)ByTestId` nullable
- Add null-safe test cases to ensure null can be passed statically, and throws as expected
- Update changelog

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_test/blob/master/CONTRIBUTING.md#manual-testing-criteria
