### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   js: ^0.6.1+1
-  meta: ^1.8.0
+  meta: ^1.16.0
   over_react: ^5.0.0
   react: ^7.0.0
   test: ^1.21.1


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)