### PR TITLE
FED-3275 React 18 Prep

### DIFF
--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -585,9 +585,11 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
       final originalConsoleError = context['console']['error'] as JsFunction;
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
-        consoleErrors.add(message);
-        originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
-            thisArg: self);
+        if(!shouldFilterOutLog(message)) {
+          consoleErrors.add(message);
+          originalConsoleError
+              .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+        }
       });
 
       final reactComponentFactory = factory().componentFactory as
@@ -662,9 +664,11 @@ void testRequiredProps(BuilderOnlyUiFactory factory, dynamic childrenFactory()) 
       final originalConsoleError = context['console']['error'] as JsFunction;
       addTearDown(() => context['console']['error'] = originalConsoleError);
       context['console']['error'] = JsFunction.withThis((self, [message, arg1, arg2, arg3,  arg4, arg5]) {
-        consoleErrors.add(message);
-        originalConsoleError.apply([message, arg1, arg2, arg3,  arg4, arg5],
-            thisArg: self);
+        if(!shouldFilterOutLog(message)) {
+          consoleErrors.add(message);
+          originalConsoleError
+              .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+        }
       });
 
       final reactComponentFactory = factory().componentFactory as

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -17,6 +17,12 @@ import 'dart:js';
 
 import 'package:react/react_client/react_interop.dart';
 
+// Do similar suppression as https://github.com/Workiva/react-dart/pull/413 - we can come back later and align this with the RTL solution.
+bool shouldFilterOutLog(String log) {
+  if(log.startsWith('Warning: ReactDOM.render is no longer supported in React 18.')) return true;
+  return false;
+}
+
 /// Runs a provided callback and returns the logs that occur during the runtime
 /// of that function.
 ///
@@ -51,11 +57,13 @@ List<String?> recordConsoleLogs(
     consoleRefs[config] = context['console'][config];
     context['console'][config] =
         JsFunction.withThis((self, [message, arg1, arg2, arg3, arg4, arg5]) {
-      // NOTE: Using console.log or print within this function will cause an infinite
-      // loop when the logType is set to `log`.
-      consoleLogs.add(message);
-      consoleRefs[config]!
-          .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+          if(!shouldFilterOutLog(message)) {
+        // NOTE: Using console.log or print within this function will cause an infinite
+        // loop when the logType is set to `log`.
+        consoleLogs.add(message);
+        consoleRefs[config]!
+            .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+      }
     });
   }
 
@@ -98,11 +106,13 @@ FutureOr<List<String?>> recordConsoleLogsAsync(
     consoleRefs[config] = context['console'][config];
     context['console'][config] =
         JsFunction.withThis((self, [message, arg1, arg2, arg3, arg4, arg5]) {
-      // NOTE: Using console.log or print within this function will cause an infinite
-      // loop when the logType is set to `log`.
-      consoleLogs.add(message);
-      consoleRefs[config]!
-          .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+          if(!shouldFilterOutLog(message)) {
+        // NOTE: Using console.log or print within this function will cause an infinite
+        // loop when the logType is set to `log`.
+        consoleLogs.add(message);
+        consoleRefs[config]!
+            .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+      }
     });
   }
 

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -19,10 +19,8 @@ import 'package:react/react_client/react_interop.dart';
 
 /// Intercept console.error calls and silence warnings for each react_dom.render call,
 /// until at the very least createRoot is made available in react-dart.
-bool shouldFilterOutLog(String log) {
-  if(log.startsWith('Warning: ReactDOM.render is no longer supported in React 18.')) return true;
-  return false;
-}
+bool shouldFilterOutLog(String log) =>
+    log.startsWith('Warning: ReactDOM.render is no longer supported in React 18.');
 
 /// Runs a provided callback and returns the logs that occur during the runtime
 /// of that function.

--- a/lib/src/over_react_test/console_log_utils.dart
+++ b/lib/src/over_react_test/console_log_utils.dart
@@ -17,7 +17,8 @@ import 'dart:js';
 
 import 'package:react/react_client/react_interop.dart';
 
-// Do similar suppression as https://github.com/Workiva/react-dart/pull/413 - we can come back later and align this with the RTL solution.
+/// Intercept console.error calls and silence warnings for each react_dom.render call,
+/// until at the very least createRoot is made available in react-dart.
 bool shouldFilterOutLog(String log) {
   if(log.startsWith('Warning: ReactDOM.render is no longer supported in React 18.')) return true;
   return false;
@@ -58,12 +59,12 @@ List<String?> recordConsoleLogs(
     context['console'][config] =
         JsFunction.withThis((self, [message, arg1, arg2, arg3, arg4, arg5]) {
           if(!shouldFilterOutLog(message)) {
-        // NOTE: Using console.log or print within this function will cause an infinite
-        // loop when the logType is set to `log`.
-        consoleLogs.add(message);
-        consoleRefs[config]!
-            .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
-      }
+            // NOTE: Using console.log or print within this function will cause an infinite
+            // loop when the logType is set to `log`.
+            consoleLogs.add(message);
+            consoleRefs[config]!
+                .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+          }
     });
   }
 
@@ -107,12 +108,12 @@ FutureOr<List<String?>> recordConsoleLogsAsync(
     context['console'][config] =
         JsFunction.withThis((self, [message, arg1, arg2, arg3, arg4, arg5]) {
           if(!shouldFilterOutLog(message)) {
-        // NOTE: Using console.log or print within this function will cause an infinite
-        // loop when the logType is set to `log`.
-        consoleLogs.add(message);
-        consoleRefs[config]!
-            .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
-      }
+            // NOTE: Using console.log or print within this function will cause an infinite
+            // loop when the logType is set to `log`.
+            consoleLogs.add(message);
+            consoleRefs[config]!
+                .apply([message, arg1, arg2, arg3, arg4, arg5], thisArg: self);
+          }
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,9 +23,9 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:Workiva/react-dart.git
+      url: https://github.com/Workiva/react-dart.git
       ref: react-18-2-0
   over_react:
     git:
-      url: git@github.com:Workiva/over_react.git
+      url: https://github.com/Workiva/over_react.git
       ref: test-react-18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,13 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
   pedantic: ^1.8.0
+
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:Workiva/react-dart.git
+      ref: react-18-2-0
+  over_react:
+    git:
+      url: git@github.com:Workiva/over_react.git
+      ref: test-react-18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,3 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   dependency_validator: ^3.2.2
   pedantic: ^1.8.0
-
-dependency_overrides:
-  react:
-    git:
-      url: https://github.com/Workiva/react-dart.git
-      ref: react-18-2-0
-  over_react:
-    git:
-      url: https://github.com/Workiva/over_react.git
-      ref: test-react-18


### PR DESCRIPTION
In preparation for React 18, suppress react_dom.render warnings like in https://github.com/Workiva/react-dart/pull/413 - this is the only thing needed to get tests passing in over_react_test on React 18

## QA instructions
- [ ] Tests pass on React 18 dep overrides commit [5e2cc6f](https://github.com/Workiva/over_react_test/pull/170/commits/5e2cc6f5026f111fd7ba0e3b9755057433a5f46d) - https://github.com/Workiva/over_react_test/actions/runs/13041437185/job/36384009022
- [ ] CI passes