### PR TITLE
RM-302415 Release over_react_test 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Test Changelog
 
+## 3.0.2
+* React 18 Prep - suppress react_dom.render warnings ([#170](https://github.com/Workiva/over_react_test/pull/170))
+
+## 3.0.1
+* GHA OSS changes ([#164](https://github.com/Workiva/over_react_test/pull/164))
+* Increase minimum Dart SDK version to 2.19.0 ([#168](https://github.com/Workiva/over_react_test/pull/168))
+
 ## 3.0.0
 * Add support for Dart null safety ([#155](https://github.com/Workiva/over_react_test/pull/155))
   * SDK / Dependency Versioning:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_test
-version: 3.0.1
+version: 3.0.2
 description: A library for testing OverReact components
 homepage: https://github.com/Workiva/over_react_test/
 environment:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3275 React 18 Prep](https://github.com/Workiva/over_react_test/pull/170)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_test/compare/3.0.1...Workiva:release_over_react_test_3.0.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_test/compare/3.0.1...3.0.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4871683861643264/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4871683861643264/?repo_name=Workiva%2Fover_react_test&pull_number=171)