### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/over_react_test/common_component_util.dart
+++ b/lib/src/over_react_test/common_component_util.dart
@@ -19,7 +19,7 @@ import 'dart:js';
 import 'package:meta/meta.dart';
 import 'package:over_react/component_base.dart' as component_base;
 import 'package:over_react/over_react.dart';
-import 'package:over_react_test/over_react_test.dart';
+
 import 'package:over_react_test/src/over_react_test/props_meta.dart';
 import 'package:over_react_test/src/over_react_test/test_helpers.dart';
 import 'package:react/react_client.dart';

--- a/lib/src/over_react_test/props_meta.dart
+++ b/lib/src/over_react_test/props_meta.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:over_react/over_react.dart';
-import 'package:over_react_test/jacket.dart';
+
 import 'package:react/react_client/react_interop.dart';
 
 /// Returns the [UiComponent2.propsMeta] obtained by rendering [el].


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)